### PR TITLE
feat(services): register services for start, stop, lock, unlock

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,22 @@
 ## Introduction
 This is a Home Assistant integration for Toyota North America.
 
+## Current features
+Sensors:
+* Door lock status
+* Window/Moonroof status
+* Trunk Status
+* Real time location
+* Last Parked Location
+* Tire Pressure
+* Fuel Level
+* Odometer
+* Oil Status
+* Key Fob Battery Status
+
+Services:
+* Lock/Unlock Doors
+* Remote Start/Stop Engine
 ## Installation
 ### HACS
 1. Install HACS: https://hacs.xyz/docs/setup/download

--- a/custom_components/toyota_na/__init__.py
+++ b/custom_components/toyota_na/__init__.py
@@ -3,16 +3,11 @@ from datetime import timedelta
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.helpers import (
-    device_registry as dr,
-    service,
-)
+from homeassistant.helpers import device_registry as dr, service
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from toyota_na import ToyotaOneClient, ToyotaOneAuth
 from toyota_na.exceptions import AuthError, LoginError
-
-import voluptuous as vol
 
 from .const import DOMAIN
 
@@ -71,7 +66,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                 _LOGGER.info(
                     "Handling service call %s for %s ",
                     remote_action,
-                    vin,
+                    vin
                 )
 
                 await client.remote_request(vin, remote_action)

--- a/custom_components/toyota_na/manifest.json
+++ b/custom_components/toyota_na/manifest.json
@@ -6,8 +6,8 @@
     "config_flow": true,
     "documentation": "https://github.com/widewing/ha_toyota_na",
     "codeowners": ["@widewing"],
-    "requirements": ["toyota-na==1.0.0"],
+    "requirements": ["toyota-na==1.1.0"],
     "issue_tracker": "https://github.com/widewing/ha-toyota-na/issues",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "iot_class": "cloud_polling"
 }

--- a/custom_components/toyota_na/services.yaml
+++ b/custom_components/toyota_na/services.yaml
@@ -1,0 +1,40 @@
+door_lock:
+  description: Remote lock your Toyota vehicle.
+  fields:
+    vehicle:
+      description:
+        Device (vehicle) you wish to lock.
+      required: true
+      selector:
+        device:
+          integration: toyota_na
+door_unlock:
+  description: Remote unlock your Toyota vehicle.
+  fields:
+    vehicle:
+      description:
+        Device (vehicle) you wish to unlock.
+      required: true
+      selector:
+        device:
+          integration: toyota_na
+engine_start:
+  description: Remote start your Toyota vehicle.
+  fields:
+    vehicle:
+      description:
+        Device (vehicle) you wish to start.
+      required: true
+      selector:
+        device:
+          integration: toyota_na
+engine_stop:
+  description: Remote stop your Toyota vehicle.
+  fields:
+    vehicle:
+      description:
+        Device (vehicle) you wish to stop.
+      required: true
+      selector:
+        device:
+          integration: toyota_na


### PR DESCRIPTION
Closes https://github.com/widewing/ha-toyota-na/issues/5

Registers a handful of services to allow HA users to control door locks and start/stop the vehicle remotely.

Long term I'd love to turn these into switches, but we need to improve the door lock state tracking and figure out how to tell if the vehicle is already running.