### PR TITLE
fix(component): filter out vehicles without active remote subscription

### DIFF
--- a/custom_components/toyota_na/__init__.py
+++ b/custom_components/toyota_na/__init__.py
@@ -17,7 +17,7 @@ PLATFORMS = ["sensor", "device_tracker"]
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     hass.data.setdefault(DOMAIN, {}).setdefault(entry.entry_id, {})
-    
+
     client = ToyotaOneClient(
         ToyotaOneAuth(
             initial_tokens=entry.data["tokens"],
@@ -28,7 +28,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         await client.auth.check_tokens()
     except AuthError as e:
         raise ConfigEntryAuthFailed(e) from e
-    
+
     coordinator = DataUpdateCoordinator(
         hass,
         _LOGGER,
@@ -60,6 +60,8 @@ async def update_vehicles_status(client: ToyotaOneClient, entry: ConfigEntry):
         vehicles = await client.get_user_vehicle_list()
         vehicles = {v["vin"]: {"info": v} for v in vehicles}
         for vin, vehicle in vehicles.items():
+            if vehicle["info"]["remoteSubscriptionStatus"] != 'ACTIVE':
+                continue
             try:
                 vehicle["status"] = await client.get_vehicle_status(vin)
             except Exception as e:


### PR DESCRIPTION
This should fix this https://github.com/DurgNomis-drol/mytoyota/issues/7#issuecomment-1006668046

From what I can tell the `remoteSubscriptionStatus` is what is required to utilize the endpoints we're hitting. So if a vehicle doesn't have an existing subscription we'll ignore it. The nice part about this is the user just needs to activate the vehicle and the next time HA update the integration (currently ~1 minute) it'll get sucked in without the user needing to restart.