### PR TITLE
feat(device): default name to display model

### DIFF
--- a/custom_components/toyota_na/base_entity.py
+++ b/custom_components/toyota_na/base_entity.py
@@ -21,11 +21,11 @@ class ToyotaNABaseEntity(CoordinatorEntity):
     def device_info(self):
         return {
             "identifiers": {(DOMAIN, self.vin)},
-            "name": self.vin,
+            "name": self.vehicle_info["displayModelDescription"],
             "model": f'{self.vehicle_info["modelYear"]} {self.vehicle_info["modelDescription"]}',
             "manufacturer": "Toyota Motor North America",
         }
-    
+
     @property
     def vehicle(self):
         return self.coordinator.data[self.vin]


### PR DESCRIPTION
I don't think the vin is required in the device info name for identification purposes in the HA internals, so I've switched it to the vehicle model description so it's more clear to the user which device they're looking at.

It makes the default entity names nicer too without impacting the unique_id in the entity_id

![image](https://user-images.githubusercontent.com/577219/150644973-dfb35318-0ac5-48ef-9b8f-2003dab247f0.png)

