### PR TITLE
Feature Refresh EV Vehicle Statuses

### DIFF
--- a/custom_components/toyota_na/__init__.py
+++ b/custom_components/toyota_na/__init__.py
@@ -8,10 +8,8 @@ from toyota_na.client import ToyotaOneClient
 
 # Patch client code
 from .patch_client import get_electric_realtime_status, get_electric_status, api_request
-
 ToyotaOneClient.get_electric_realtime_status = get_electric_realtime_status
 ToyotaOneClient.get_electric_status = get_electric_status
-ToyotaOneClient._auth_headers = _auth_headers
 ToyotaOneClient.api_request = api_request
 
 # Patch base_vehicle
@@ -80,23 +78,21 @@ async def async_setup(hass: HomeAssistant, _processed_config) -> bool:
 
         # There is currently not a case with this integration where
         # the device will have more or less than one config entry
-        if len(device.config_entries) == 0:
+        if len(device.config_entries) != 1:
             _LOGGER.warning("Device missing config entry")
             return
 
-        for entry_id in device.config_entries:
-            if entry_id not in hass.data[DOMAIN]:
-                _LOGGER.warning("Config entry not found")
-                continue
+        entry_id = list(device.config_entries)[0]
 
-            if "coordinator" not in hass.data[DOMAIN][entry_id]:
-                _LOGGER.warning("Coordinator not found")
-                continue
+        if entry_id not in hass.data[DOMAIN]:
+            _LOGGER.warning("Config entry not found")
+            return
 
-            coordinator = hass.data[DOMAIN][entry_id]["coordinator"]
-            if coordinator.data is None:
-                _LOGGER.warning("No coordinator data")
-                continue
+        if "coordinator" not in hass.data[DOMAIN][entry_id]:
+            _LOGGER.warning("Coordinator not found")
+            return
+
+        coordinator = hass.data[DOMAIN][entry_id]["coordinator"]
 
         if coordinator.data is None:
             _LOGGER.warning("No coordinator data")

--- a/custom_components/toyota_na/patch_client.py
+++ b/custom_components/toyota_na/patch_client.py
@@ -1,13 +1,33 @@
 import logging
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlencode
 
 import aiohttp
 
 API_GATEWAY = "https://oneapi-east.telematicsct.com/"
 
-async def get_electric_status(self, vin):
+async def get_electric_realtime_status(self, vin, generation="17CYPLUS"):
+    realtime_electric_status = await self.api_post(
+        "v2/electric/realtime-status",
+        {},
+        {
+            "device-id": self.auth.get_device_id(),
+            "vin": vin,
+        },
+    )
+    if generation == "17CYPLUS":
+        return await self.get_electric_status(vin, realtime_electric_status["appRequestNo"])
+    elif realtime_electric_status["returnCode"] == "ONE-RES-10000":
+        return await self.get_electric_status(vin)
+
+
+async def get_electric_status(self, vin, realtime_status=None):
+    url = "v2/electric/status"
+    if realtime_status:
+        query_params = {"realtime-status": realtime_status}
+        url += "?" + urlencode(query_params)
+
     electric_status = await self.api_get(
-        "v2/electric/status", {"VIN": vin}
+        url, {"VIN": vin}
     )
     if "vehicleInfo" in electric_status:
         return electric_status

--- a/custom_components/toyota_na/patch_seventeen_cy.py
+++ b/custom_components/toyota_na/patch_seventeen_cy.py
@@ -139,6 +139,17 @@ class SeventeenCYToyotaVehicle(ToyotaVehicle):
         """Instructs Toyota's systems to ping the vehicle to upload a fresh status. Useful when certain actions have been taken, such as locking or unlocking doors."""
         await self._client.send_refresh_status(self._vin, self._generation.value)
 
+        """Tell Toyota to refresh electric status if applicable"""
+        try:
+            if self._has_electric:
+                # electric_status
+                electric_status = await self._client.get_electric_realtime_status(self.vin, self._generation.value)
+                if electric_status is not None:
+                    self._parse_electric_status(electric_status)
+        except Exception as e:
+            _LOGGER.error(e)
+            pass
+
     async def send_command(self, command: RemoteRequestCommand) -> None:
         """Start the engine. Periodically refreshes the vehicle status to determine if the engine is running."""
         await self._client.remote_request(

--- a/custom_components/toyota_na/patch_seventeen_cy_plus.py
+++ b/custom_components/toyota_na/patch_seventeen_cy_plus.py
@@ -126,6 +126,17 @@ class SeventeenCYPlusToyotaVehicle(ToyotaVehicle):
         """Instructs Toyota's systems to ping the vehicle to upload a fresh status. Useful when certain actions have been taken, such as locking or unlocking doors."""
         await self._client.send_refresh_status(self._vin)
 
+        """Tell Toyota to refresh electric status if applicable"""
+        try:
+            if self._has_electric:
+                # electric_status
+                electric_status = await self._client.get_electric_realtime_status(self.vin)
+                if electric_status is not None:
+                    self._parse_electric_status(electric_status)
+        except Exception as e:
+            _LOGGER.error(e)
+            pass
+
     async def send_command(self, command: RemoteRequestCommand) -> None:
         """Start the engine. Periodically refreshes the vehicle status to determine if the engine is running."""
         await self._client.remote_request(self._vin, self._command_map[command])


### PR DESCRIPTION
I noticed refreshing statuses would not refresh EV statuses when running the refresh action. I have been "hacking" this via toggling my charger that I can also control in home assistant because the vehicle sends an update when charging state changes automatically. This solution is probably not a great method and probably not great for the health of battery / charger.

I took a look and there is a refresh battery button in the app so I looked into it and created this solution. I also noticed the app gets EV Status afterwards and will call the refresh afterwards differently depending on the generation.

With that all in mind, the changes I have added in here will refresh the battery info when the other statuses are refreshed or the action is called. To reduce API requests and errors, it will only if the car is an EV and will handle it the same way the app does with clicking the refresh button on the battery screen no matter the generation.

I also wanted to note I didn't really change much in __init__.py, but since the project lacks standard formatting, I assume this is happening because I did this on linux and the encoding or new lines are different.