### PR TITLE
Fix telemetry endpoint

### DIFF
--- a/custom_components/toyota_na/__init__.py
+++ b/custom_components/toyota_na/__init__.py
@@ -7,11 +7,12 @@ from toyota_na.auth import ToyotaOneAuth
 from toyota_na.client import ToyotaOneClient
 
 # Patch client code
-from .patch_client import get_electric_realtime_status, get_electric_status, api_request, _auth_headers
+from .patch_client import get_electric_realtime_status, get_electric_status, api_request, _auth_headers, get_telemetry
 ToyotaOneClient.get_electric_realtime_status = get_electric_realtime_status
 ToyotaOneClient.get_electric_status = get_electric_status
 ToyotaOneClient.api_request = api_request
 ToyotaOneClient._auth_headers = _auth_headers
+ToyotaOneClient.get_telemetry = get_telemetry
 
 # Patch base_vehicle
 import toyota_na.vehicle.base_vehicle

--- a/custom_components/toyota_na/patch_base_vehicle.py
+++ b/custom_components/toyota_na/patch_base_vehicle.py
@@ -102,6 +102,7 @@ class ToyotaVehicle(ABC):
     _model_year: str
     _generation: ApiVehicleGeneration
     _vin: str
+    _region: str
 
     def __init__(
         self,
@@ -111,6 +112,7 @@ class ToyotaVehicle(ABC):
         model_name: str,
         model_year: str,
         vin: str,
+        region: str,
         generation: ApiVehicleGeneration,
     ):
         """
@@ -127,6 +129,7 @@ class ToyotaVehicle(ABC):
         self._model_name = model_name
         self._model_year = model_year
         self._vin = vin
+        self._region = region
 
     @abstractmethod
     async def poll_vehicle_refresh(self) -> None:

--- a/custom_components/toyota_na/patch_client.py
+++ b/custom_components/toyota_na/patch_client.py
@@ -5,6 +5,11 @@ import aiohttp
 
 API_GATEWAY = "https://onecdn.telematicsct.com/oneapi/"
 
+async def get_telemetry(self, vin, region, generation="17CYPLUS"):
+    return await self.api_get(
+        "/v2/telemetry", {"VIN": vin, "GENERATION": generation, "X-BRAND": "T", "x-region": region}
+    )
+
 async def _auth_headers(self):
     return {
         "AUTHORIZATION": "Bearer " + await self.auth.get_access_token(),

--- a/custom_components/toyota_na/patch_seventeen_cy.py
+++ b/custom_components/toyota_na/patch_seventeen_cy.py
@@ -79,6 +79,7 @@ class SeventeenCYToyotaVehicle(ToyotaVehicle):
         model_name: str,
         model_year: str,
         vin: str,
+        region: str,
     ):
         self._has_remote_subscription = has_remote_subscription
         self._has_electric = has_electric
@@ -91,6 +92,7 @@ class SeventeenCYToyotaVehicle(ToyotaVehicle):
             model_name,
             model_year,
             vin,
+            region,
             ApiVehicleGeneration.CY17,
         )
 
@@ -109,7 +111,7 @@ class SeventeenCYToyotaVehicle(ToyotaVehicle):
 
         try:
             # telemetry
-            telemetry = await self._client.get_telemetry(self._vin, self._generation.value)
+            telemetry = await self._client.get_telemetry(self._vin, self._region, self._generation.value)
             self._parse_telemetry(telemetry)
         except Exception as e:
             _LOGGER.error(e)

--- a/custom_components/toyota_na/patch_seventeen_cy_plus.py
+++ b/custom_components/toyota_na/patch_seventeen_cy_plus.py
@@ -70,6 +70,7 @@ class SeventeenCYPlusToyotaVehicle(ToyotaVehicle):
         model_name: str,
         model_year: str,
         vin: str,
+        region: str,
     ):
         self._has_remote_subscription = has_remote_subscription
         self._has_electric = has_electric
@@ -82,6 +83,7 @@ class SeventeenCYPlusToyotaVehicle(ToyotaVehicle):
             model_name,
             model_year,
             vin,
+            region,
             ApiVehicleGeneration.CY17PLUS,
         )
 
@@ -98,7 +100,7 @@ class SeventeenCYPlusToyotaVehicle(ToyotaVehicle):
 
         try:
             # telemetry
-            telemetry = await self._client.get_telemetry(self._vin)
+            telemetry = await self._client.get_telemetry(self._vin, self._region)
             self._parse_telemetry(telemetry)
         except Exception as e:
             _LOGGER.error(e)

--- a/custom_components/toyota_na/patch_vehicle.py
+++ b/custom_components/toyota_na/patch_vehicle.py
@@ -25,6 +25,7 @@ async def get_vehicles(client: ToyotaOneClient) -> list[ToyotaVehicle]:
                 model_name=vehicle["modelName"],
                 model_year=vehicle["modelYear"],
                 vin=vehicle["vin"],
+                region=vehicle["region"],
             )
 
         elif ApiVehicleGeneration(vehicle["generation"]) == ApiVehicleGeneration.CY17:
@@ -35,6 +36,7 @@ async def get_vehicles(client: ToyotaOneClient) -> list[ToyotaVehicle]:
                 model_name=vehicle["modelName"],
                 model_year=vehicle["modelYear"],
                 vin=vehicle["vin"],
+                region=vehicle["region"],
             )
 
         await vehicle.update()


### PR DESCRIPTION
Telemetry endpoint is broken and requires x-region to be set in the header. 

Disclaimers:
1. I tested this and confirmed telemetry data is loading properly again for 17CYPLUS. I do not own the other generation, but I assume it is needed for it too.
2. I own a different brand, not a Toyota, so I am not sure if this is affecting Toyota's yet. Odometer / Next service / Last update timestamps would be missing.