### PR TITLE
Fix config flow for multi-device / multi-vehicle

### DIFF
--- a/custom_components/toyota_na/patch_vehicle.py
+++ b/custom_components/toyota_na/patch_vehicle.py
@@ -39,7 +39,9 @@ async def get_vehicles(client: ToyotaOneClient) -> list[ToyotaVehicle]:
                 region=vehicle["region"],
             )
 
-        await vehicle.update()
-        vehicles.append(vehicle)
+        vehicle_update = vehicle.update()
+        if vehicle_update:
+            await vehicle_update
+            vehicles.append(vehicle)
 
     return vehicles


### PR DESCRIPTION
Fixes an issue found during config setup when you have multiple vehicles in your Toyota account but not all vehicles have a valid connection anymore (pre-LTE vehicles). This prevents a NoneType exception when awaiting since the result of `vehicle.update()` is None when attempting to update a pre-LTE vehicle.
