### PR TITLE
Return state of class from the ToyotaNumericSensor::state_class function

### DIFF
--- a/custom_components/toyota_na/sensor.py
+++ b/custom_components/toyota_na/sensor.py
@@ -83,7 +83,7 @@ class ToyotaNumericSensor(ToyotaNABaseEntity):
 
     @property
     def state_class(self):
-        return self.feature(self._vehicle_feature) is not None
+        return self._state_class
 
     @property
     def unit_of_measurement(self):


### PR DESCRIPTION
Hi there. While reading the code I realized that the `state_class` method of `ToyotaNumericSensor` returns a boolean instead of the actual state, thus HA is unable to create long term statistics of the numeric sensors of this integration. 
This PR should fix the problem. 