### PR TITLE
Fix 21MM/TLS3 status handling and lock entity state

### DIFF
--- a/custom_components/toyota_na/lock.py
+++ b/custom_components/toyota_na/lock.py
@@ -63,24 +63,19 @@ class ToyotaLock(ToyotaNABaseEntity, LockEntity):
 
     @property
     def is_locked(self):
-        _is_locked = True
+        if self.vehicle is None:
+            return None
 
-        if self.vehicle is not None:
+        all_locks = [
+            feature
+            for feature in self.vehicle.features.values()
+            if isinstance(feature, ToyotaLockableOpening)
+        ]
 
-            all_locks = [
-                feature
-                for feature in self.vehicle.features.values()
-                if isinstance(feature, ToyotaLockableOpening)
-            ]
+        if not all_locks:
+            return None
 
-            for lock in all_locks:
-                if lock.locked is False:
-                    _is_locked = False
-
-        else:
-            _is_locked = False
-
-        return _is_locked
+        return all(lock.locked for lock in all_locks)
 
     @property
     def is_locking(self):

--- a/custom_components/toyota_na/manifest.json
+++ b/custom_components/toyota_na/manifest.json
@@ -7,7 +7,7 @@
     "codeowners": ["@vanstinator, @widewing"],
     "requirements": ["toyota-na==2.1.1"],
     "issue_tracker": "https://github.com/widewing/ha-toyota-na/issues",
-    "version": "2.6.5",
+    "version": "2.7.0",
     "iot_class": "cloud_polling"
 }
 


### PR DESCRIPTION
## Summary
Follow-up to #153. Addresses remaining issues with 21MM/TLS3 vehicles discovered during API endpoint testing:

- **Lock entity shows false "Locked"**: When the status API returns no data, `is_locked` defaulted to `True`. Now returns `None` so HA shows "Unknown" instead of a misleading "Locked" state.
- **Remove broken v1 endpoints**: `v1/global/remote/status` and `v1/global/remote/engine-status` return 400 for all 21MM vehicles since ~Feb 4 2026. Removed from the fallback chain to avoid wasted requests and log noise. Uses `v2/remote/status` with `GENERATION` header directly.
- **Use 17cyplus-specific methods**: `update()`, `poll_vehicle_refresh()`, and `send_command()` now call the patched `_17cyplus` methods directly instead of going through the generic dispatcher (which doesn't know about the patched endpoints).
- **Cache last successful status**: When `v2/remote/status` returns null `vehicleStatus` (common for 21MM), re-parses the last known good response so door/lock/window features persist across update cycles instead of disappearing.
- **Downgrade refresh warning**: `poll_vehicle_refresh` failure logged at `debug` instead of `warning` since rate-limiting (429) is expected.
- Bump version to 2.7.0

## Test plan
- [ ] Verify lock entity shows "Unknown" instead of "Locked" when status API returns no data
- [ ] Verify door/lock features persist across polls when v2/remote/status returns null
- [ ] Verify remote commands (lock/unlock/start/stop) still work
- [ ] Verify telemetry (fuel, tires, odometer, location) continues working
- [ ] Verify 17CY (legacy) vehicles are unaffected