### PR TITLE
[codex] Fix Home Assistant deprecation warnings

### DIFF
--- a/custom_components/toyota_na/__init__.py
+++ b/custom_components/toyota_na/__init__.py
@@ -96,7 +96,7 @@ _LOGGER = logging.getLogger(__name__)
 PLATFORMS = ["binary_sensor", "device_tracker", "lock", "sensor"]
 
 async def async_setup(hass: HomeAssistant, _processed_config) -> bool:
-    @service.verify_domain_control(hass, DOMAIN)
+    @service.verify_domain_control(DOMAIN)
     async def async_service_handle(service_call: ServiceCall) -> None:
         """Handle dispatched services."""
 

--- a/custom_components/toyota_na/device_tracker.py
+++ b/custom_components/toyota_na/device_tracker.py
@@ -5,8 +5,7 @@ from typing import Any, cast
 from toyota_na.vehicle.base_vehicle import ToyotaVehicle, VehicleFeatures
 from toyota_na.vehicle.entity_types.ToyotaLocation import ToyotaLocation
 
-from homeassistant.components.device_tracker import SourceType
-from homeassistant.components.device_tracker.config_entry import TrackerEntity
+from homeassistant.components.device_tracker import SourceType, TrackerEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback

--- a/custom_components/toyota_na/manifest.json
+++ b/custom_components/toyota_na/manifest.json
@@ -7,7 +7,7 @@
     "codeowners": ["@vanstinator, @widewing"],
     "requirements": ["toyota-na==2.1.1"],
     "issue_tracker": "https://github.com/widewing/ha-toyota-na/issues",
-    "version": "2.6.9",
+    "version": "2.6.10",
     "iot_class": "cloud_polling"
 }
 


### PR DESCRIPTION
## Summary
- call `verify_domain_control` without the deprecated `hass` argument
- import `TrackerEntity` from `homeassistant.components.device_tracker` instead of the deprecated `config_entry` alias

## Validation
- one-off AST check for both deprecated API usages
- `python3 -m compileall custom_components/toyota_na`
- `git diff --check`

Closes #154