### PR TITLE
Unit Fixes: timestamps, charge time, connector status.

### DIFF
--- a/custom_components/toyota_na/const.py
+++ b/custom_components/toyota_na/const.py
@@ -370,7 +370,7 @@ SENSORS = [
         "electric": True,
     },
     {
-        "state_class": SensorStateClass.MEASUREMENT,
+        "state_class": None,
         "icon": "mdi:ev-plug-type1",
         "feature": VehicleFeatures.ConnectorStatus,
         "name": "Connector Status",

--- a/custom_components/toyota_na/const.py
+++ b/custom_components/toyota_na/const.py
@@ -1,7 +1,7 @@
 from toyota_na.vehicle.base_vehicle import VehicleFeatures
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
-from homeassistant.components.sensor import SensorStateClass
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.const import PERCENTAGE, UnitOfPressure, UnitOfTime
 
 from toyota_na.vehicle.base_vehicle import RemoteRequestCommand
@@ -305,7 +305,8 @@ SENSORS = [
         "electric": True,
     },
     {
-        "state_class": SensorStateClass.MEASUREMENT,
+        "device_class": SensorDeviceClass.TIMESTAMP,
+        "state_class": None,
         "icon": "mdi:gauge",
         "feature": VehicleFeatures.LastTimeStamp,
         "name": "Last Update Timestamp",
@@ -314,7 +315,8 @@ SENSORS = [
         "electric": False,
     },
     {
-        "state_class": SensorStateClass.MEASUREMENT,
+        "device_class": SensorDeviceClass.TIMESTAMP,
+        "state_class": None,
         "icon": "mdi:gauge",
         "feature": VehicleFeatures.LastTirePressureTimeStamp,
         "name": "Last Tire Pressure Update Timestamp",

--- a/custom_components/toyota_na/const.py
+++ b/custom_components/toyota_na/const.py
@@ -2,7 +2,7 @@ from toyota_na.vehicle.base_vehicle import VehicleFeatures
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.sensor import SensorStateClass
-from homeassistant.const import PERCENTAGE, UnitOfPressure
+from homeassistant.const import PERCENTAGE, UnitOfPressure, UnitOfTime
 
 from toyota_na.vehicle.base_vehicle import RemoteRequestCommand
 
@@ -345,7 +345,7 @@ SENSORS = [
         "icon": "mdi:clock-outline",
         "feature": VehicleFeatures.RemainingChargeTime,
         "name": "Remaining Charge Time",
-        "unit": "",
+        "unit": UnitOfTime.MINUTES,
         "subscription": True,
         "electric": True,
     },

--- a/custom_components/toyota_na/patch_seventeen_cy.py
+++ b/custom_components/toyota_na/patch_seventeen_cy.py
@@ -201,7 +201,13 @@ class SeventeenCYToyotaVehicle(ToyotaVehicle):
         self._features[VehicleFeatures.RemainingChargeTime] = ToyotaNumeric(chargeInfo.get("remainingChargeTime"), "min")
         self._features[VehicleFeatures.EvTravelableDistance] = ToyotaNumeric(chargeInfo.get("evTravelableDistance"), "")
         self._features[VehicleFeatures.ChargeType] = ToyotaNumeric(chargeInfo.get("chargeType"), "")
-        self._features[VehicleFeatures.ConnectorStatus] = ToyotaNumeric(chargeInfo.get("connectorStatus"), "")
+        raw_status = chargeInfo.get("connectorStatus")
+        connector_status = {
+            2: "Disconnected",
+            4: "Unlocked",
+            5: "Locked",
+        }.get(raw_status if isinstance(raw_status, int) else int(raw_status) if raw_status is not None and str(raw_status).isdigit() else raw_status, raw_status)
+        self._features[VehicleFeatures.ConnectorStatus] = ToyotaNumeric(connector_status, "")
         self._features[VehicleFeatures.ChargingStatus] = ToyotaOpening(chargeInfo.get("connectorStatus") != 5)
 
     #

--- a/custom_components/toyota_na/patch_seventeen_cy.py
+++ b/custom_components/toyota_na/patch_seventeen_cy.py
@@ -198,7 +198,7 @@ class SeventeenCYToyotaVehicle(ToyotaVehicle):
         self._features[VehicleFeatures.ChargeDistanceAC] = ToyotaNumeric(chargeInfo.get("evDistanceAC"), chargeInfo.get("evDistanceUnit"))
         self._features[VehicleFeatures.ChargeLevel] = ToyotaNumeric(chargeInfo.get("chargeRemainingAmount"), "%")
         self._features[VehicleFeatures.PlugStatus] = ToyotaNumeric(chargeInfo.get("plugStatus"), "")
-        self._features[VehicleFeatures.RemainingChargeTime] = ToyotaNumeric(chargeInfo.get("remainingChargeTime"), "")
+        self._features[VehicleFeatures.RemainingChargeTime] = ToyotaNumeric(chargeInfo.get("remainingChargeTime"), "min")
         self._features[VehicleFeatures.EvTravelableDistance] = ToyotaNumeric(chargeInfo.get("evTravelableDistance"), "")
         self._features[VehicleFeatures.ChargeType] = ToyotaNumeric(chargeInfo.get("chargeType"), "")
         self._features[VehicleFeatures.ConnectorStatus] = ToyotaNumeric(chargeInfo.get("connectorStatus"), "")

--- a/custom_components/toyota_na/patch_seventeen_cy_plus.py
+++ b/custom_components/toyota_na/patch_seventeen_cy_plus.py
@@ -223,7 +223,13 @@ class SeventeenCYPlusToyotaVehicle(ToyotaVehicle):
         self._features[VehicleFeatures.RemainingChargeTime] = ToyotaNumeric(chargeInfo.get("remainingChargeTime"), "min")
         self._features[VehicleFeatures.EvTravelableDistance] = ToyotaNumeric(chargeInfo.get("evTravelableDistance"), "")
         self._features[VehicleFeatures.ChargeType] = ToyotaNumeric(chargeInfo.get("chargeType"), "")
-        self._features[VehicleFeatures.ConnectorStatus] = ToyotaNumeric(chargeInfo.get("connectorStatus"), "")
+        raw_status = chargeInfo.get("connectorStatus")
+        connector_status = {
+            2: "Disconnected",
+            4: "Unlocked",
+            5: "Locked",
+        }.get(raw_status if isinstance(raw_status, int) else int(raw_status) if raw_status is not None and str(raw_status).isdigit() else raw_status, raw_status)
+        self._features[VehicleFeatures.ConnectorStatus] = ToyotaNumeric(connector_status, "")
         self._features[VehicleFeatures.ChargingStatus] = ToyotaOpening(chargeInfo.get("connectorStatus") != 5)
 
     #

--- a/custom_components/toyota_na/patch_seventeen_cy_plus.py
+++ b/custom_components/toyota_na/patch_seventeen_cy_plus.py
@@ -220,7 +220,7 @@ class SeventeenCYPlusToyotaVehicle(ToyotaVehicle):
         self._features[VehicleFeatures.ChargeDistanceAC] = ToyotaNumeric(chargeInfo.get("evDistanceAC"), chargeInfo.get("evDistanceUnit"))
         self._features[VehicleFeatures.ChargeLevel] = ToyotaNumeric(chargeInfo.get("chargeRemainingAmount"), "%")
         self._features[VehicleFeatures.PlugStatus] = ToyotaNumeric(chargeInfo.get("plugStatus"), "")
-        self._features[VehicleFeatures.RemainingChargeTime] = ToyotaNumeric(chargeInfo.get("remainingChargeTime"), "")
+        self._features[VehicleFeatures.RemainingChargeTime] = ToyotaNumeric(chargeInfo.get("remainingChargeTime"), "min")
         self._features[VehicleFeatures.EvTravelableDistance] = ToyotaNumeric(chargeInfo.get("evTravelableDistance"), "")
         self._features[VehicleFeatures.ChargeType] = ToyotaNumeric(chargeInfo.get("chargeType"), "")
         self._features[VehicleFeatures.ConnectorStatus] = ToyotaNumeric(chargeInfo.get("connectorStatus"), "")

--- a/custom_components/toyota_na/sensor.py
+++ b/custom_components/toyota_na/sensor.py
@@ -3,7 +3,7 @@ from typing import Any, Union, cast
 from toyota_na.vehicle.base_vehicle import ToyotaVehicle, VehicleFeatures
 from toyota_na.vehicle.entity_types.ToyotaNumeric import ToyotaNumeric
 
-from homeassistant.components.sensor import SensorStateClass
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfLength
 from homeassistant.core import HomeAssistant
@@ -43,7 +43,8 @@ async def async_setup_entry(
                         cast(VehicleFeatures, feature_sensor["feature"]),
                         cast(str, entity_config["icon"]),
                         cast(str, entity_config["unit"]),
-                        cast(SensorStateClass, entity_config["state_class"]),
+                        cast(SensorStateClass, entity_config.get("state_class")),
+                        cast(SensorDeviceClass, entity_config.get("device_class")),
                         coordinator,
                         entity_config["name"],
                         vehicle.vin,
@@ -62,7 +63,8 @@ class ToyotaNumericSensor(ToyotaNABaseEntity):
         vehicle_feature: VehicleFeatures,
         icon: str,
         unit_of_measurement: str,
-        state_class: Union[SensorStateClass, str],
+        state_class: Union[SensorStateClass, str, None],
+        device_class: Union[SensorDeviceClass, str, None],
         *args: Any,
     ):
         super().__init__(*args)
@@ -70,15 +72,23 @@ class ToyotaNumericSensor(ToyotaNABaseEntity):
         self._state_class = state_class
         self._unit_of_measurement = unit_of_measurement
         self._vehicle_feature = vehicle_feature
+        self._device_class = device_class
 
     @property
     def icon(self) -> str:
         return self._icon
 
     @property
+    def device_class(self):
+        return self._device_class
+
+    @property
     def state(self):
         feat = cast(ToyotaNumeric, self.feature(self._vehicle_feature))
         if feat:
+            if self._device_class == SensorDeviceClass.TIMESTAMP and feat.value is not None:
+                import datetime
+                return datetime.datetime.fromtimestamp(feat.value, datetime.timezone.utc)
             return feat.value
 
     @property


### PR DESCRIPTION
* Add proper units to the timestamps, the remaining charge time.
* Convert the connector status to report in enum strings instead of opaque integers. 

Fix #178