### PR TITLE
feat: fix shared-vehicle collisions, add buttons, and misc bug fixes

### DIFF
--- a/custom_components/toyota_na/__init__.py
+++ b/custom_components/toyota_na/__init__.py
@@ -93,7 +93,7 @@ from .const import (
 )
 
 _LOGGER = logging.getLogger(__name__)
-PLATFORMS = ["binary_sensor", "device_tracker", "lock", "sensor"]
+PLATFORMS = ["binary_sensor", "button", "device_tracker", "lock", "sensor"]
 
 async def async_setup(hass: HomeAssistant, _processed_config) -> bool:
     @service.verify_domain_control(DOMAIN)

--- a/custom_components/toyota_na/__init__.py
+++ b/custom_components/toyota_na/__init__.py
@@ -73,7 +73,7 @@ from .patch_vehicle import get_vehicles
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ConfigEntryAuthFailed
-from homeassistant.helpers import device_registry as dr, service
+from homeassistant.helpers import device_registry as dr, issue_registry as ir, service
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .websocket_handler import ToyotaWebSocketHandler
@@ -87,13 +87,164 @@ from .const import (
     HAZARDS_OFF,
     DOOR_LOCK,
     DOOR_UNLOCK,
+    OPT_EXCLUDED_VINS,
     REFRESH,
     UPDATE_INTERVAL,
-    REFRESH_STATUS_INTERVAL
+    REFRESH_STATUS_INTERVAL,
+    VIN_CLAIMS,
 )
 
 _LOGGER = logging.getLogger(__name__)
 PLATFORMS = ["binary_sensor", "button", "device_tracker", "lock", "sensor"]
+
+
+def _shared_vehicle_issue_id(vin: str, entry_id: str) -> str:
+    # Scoped to (vin, entry_id) rather than just vin -- each entry only ever creates/deletes
+    # its *own* issue below, never another entry's, which is what keeps this correct with three
+    # or more accounts and avoids the winning entry ever deleting a still-valid conflict issue
+    # raised by the losing entry (the old vin-only scheme did exactly that).
+    return f"shared_vehicle_{vin}_{entry_id}"
+
+
+def async_claim_vehicles(
+    hass: HomeAssistant, entry: ConfigEntry, raw_vehicles: list
+) -> list:
+    """Filter raw_vehicles down to the ones this entry is allowed to manage.
+
+    A VIN already claimed by a *different* loaded config entry is dropped here rather than
+    proceeding to entity creation. This is what keeps a vehicle visible to two Toyota accounts
+    (Toyota "family sharing") from ever colliding: only one entry's platforms ever see it, so
+    unique_id/device identifiers never need to differ by account, and no entity ends up silently
+    bound to the wrong account's session.
+
+    Called on every refresh for every entry (there's deliberately no pre-filter skipping
+    already-claimed VINs before this): that's what lets a losing entry keep re-asserting its own
+    Repair issue every cycle, and correctly clear it once the conflict resolves, instead of going
+    silent after its first loss. The cost is a losing entry keeps polling (then discarding) a
+    vehicle it doesn't own until the user excludes it via the Configure option -- accepted, since
+    that's exactly the window this feature exists to shorten.
+    """
+    vin_claims: dict[str, str] = hass.data[DOMAIN].setdefault(VIN_CLAIMS, {})
+    claimed = []
+    for vehicle in raw_vehicles:
+        owner = vin_claims.get(vehicle.vin)
+        if owner is not None and owner != entry.entry_id:
+            other_entry = hass.config_entries.async_get_entry(owner)
+            other_title = other_entry.title if other_entry else "another account"
+            _LOGGER.warning(
+                "VIN ...%s (%s %s) is already managed by another Toyota (North America) "
+                "account (%s) in this Home Assistant instance; skipping it here. If this is a "
+                "family-shared vehicle, use this integration's Configure option to choose which "
+                "account should manage it.",
+                vehicle.vin[-4:],
+                vehicle.model_year,
+                vehicle.model_name,
+                other_title,
+            )
+            ir.async_create_issue(
+                hass,
+                DOMAIN,
+                _shared_vehicle_issue_id(vehicle.vin, entry.entry_id),
+                is_fixable=False,
+                severity=ir.IssueSeverity.WARNING,
+                translation_key="shared_vehicle",
+                translation_placeholders={
+                    "vehicle": f"{vehicle.model_year} {vehicle.model_name}",
+                    "this_account": entry.title,
+                    "managing_account": other_title,
+                },
+            )
+            continue
+        vin_claims[vehicle.vin] = entry.entry_id
+        # Only ever clear an issue *this* entry raised about not owning the vehicle -- never
+        # another entry's, since we have no way to know whether the conflict still exists from
+        # their perspective.
+        ir.async_delete_issue(hass, DOMAIN, _shared_vehicle_issue_id(vehicle.vin, entry.entry_id))
+        claimed.append(vehicle)
+    return claimed
+
+
+def async_release_vehicle_claims(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Release any VINs this entry claimed (so another entry can adopt them), and clean up any
+    Repair issues this entry raised about vehicles it *doesn't* own.
+
+    The second half matters on its own: if this entry never claimed anything (it was always the
+    losing side of a conflict) but gets removed or disabled, nothing else would ever clean up the
+    issue it raised -- it would otherwise linger in the registry forever, since only this entry's
+    own next refresh could have cleared it, and that will never happen again.
+    """
+    vin_claims: dict[str, str] = hass.data.get(DOMAIN, {}).get(VIN_CLAIMS, {})
+    for vin in [v for v, owner in vin_claims.items() if owner == entry.entry_id]:
+        del vin_claims[vin]
+
+    issue_registry = ir.async_get(hass)
+    suffix = f"_{entry.entry_id}"
+    for (issue_domain, issue_id) in list(issue_registry.issues.keys()):
+        if issue_domain == DOMAIN and issue_id.endswith(suffix):
+            ir.async_delete_issue(hass, DOMAIN, issue_id)
+
+
+def async_prune_unclaimed_devices(
+    hass: HomeAssistant, entry: ConfigEntry, vins_to_prune: set
+) -> None:
+    """Remove this entry's device for each VIN in vins_to_prune -- vehicles the user just
+    excluded via the Configure option, or vehicles just lost to another entry in a claim
+    conflict this refresh. Removing the device also removes its entities (Home Assistant's
+    entity registry listens for device removal and drops any entity whose config entry matches).
+
+    Deliberately NOT "every device whose VIN isn't in this refresh's vehicle list" -- a config
+    entry's devices persist across refreshes, but the vehicle list itself can legitimately come
+    back short (or empty) on a single poll without raising (a Toyota API hiccup, a transient
+    partial response). Since no platform here re-creates an entity once its device is removed
+    (entities are only ever created in each platform's async_setup_entry), pruning on mere
+    absence would delete real, working entities over a one-poll blip, with nothing bringing them
+    back short of a full entry reload. Pruning only for reasons we can positively confirm --  an
+    explicit exclusion, or a claim genuinely lost this cycle -- avoids that risk entirely. A
+    vehicle that's actually gone from the account (e.g. sold) isn't covered by this at all; the
+    user removes that one manually from its device page instead, which
+    async_remove_config_entry_device() below allows.
+    """
+    if not vins_to_prune:
+        return
+    device_registry = dr.async_get(hass)
+    for device in dr.async_entries_for_config_entry(device_registry, entry.entry_id):
+        vin = next((ident[1] for ident in device.identifiers if ident[0] == DOMAIN), None)
+        if vin is not None and vin in vins_to_prune:
+            device_registry.async_update_device(device.id, remove_config_entry_id=entry.entry_id)
+
+
+async def async_remove_config_entry_device(
+    hass: HomeAssistant, entry: ConfigEntry, device_entry: dr.DeviceEntry
+) -> bool:
+    """Let a user manually delete a device from its device page -- the escape hatch for a
+    vehicle async_prune_unclaimed_devices() deliberately won't touch on its own: one that's
+    disappeared from the Toyota account entirely (e.g. sold), rather than being excluded or lost
+    to a claim conflict. Unconditionally allowed: if the vehicle is actually still in this
+    entry's managed set, get_vehicles()/async_claim_vehicles() will just recreate the device on
+    the entry's next refresh, the same as manually deleting any other still-present device would.
+    """
+    return True
+
+
+async def async_update_options(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Reload the config entry, but only if the vehicle-exclusion option actually changed.
+
+    Home Assistant fires config-entry update listeners on *any* change to the entry -- data,
+    options, or title -- not just options (see ConfigEntries.async_update_entry's docstring).
+    This integration writes entry.data routinely at runtime (refreshed auth tokens roughly every
+    5-10 minutes, a last_refreshed_at timestamp every couple hours), and a naive listener would
+    force a full reload -- tearing down the coordinator, WebSocket connection, and every entity --
+    on that cadence, for every user, not just ones using the vehicle-exclusion feature. Comparing
+    against the exclusion-list snapshot taken at setup keeps this a no-op for everyone except an
+    actual options-flow submission.
+    """
+    entry_runtime = hass.data.get(DOMAIN, {}).get(entry.entry_id)
+    if entry_runtime is None:
+        return
+    new_excluded = set(entry.options.get(OPT_EXCLUDED_VINS, []))
+    if entry_runtime.get("excluded_vins_snapshot") == new_excluded:
+        return
+    await hass.config_entries.async_reload(entry.entry_id)
 
 async def async_setup(hass: HomeAssistant, _processed_config) -> bool:
     @service.verify_domain_control(DOMAIN)
@@ -108,55 +259,63 @@ async def async_setup(hass: HomeAssistant, _processed_config) -> bool:
             _LOGGER.warning("Device does not exist")
             return
 
-        # There is currently not a case with this integration where
-        # the device will have more or less than one config entry
         if len(device.config_entries) == 0:
             _LOGGER.warning("Device missing config entry")
             return
 
-        for entry_id in device.config_entries:
-            if entry_id not in hass.data[DOMAIN]:
-                _LOGGER.warning("Config entry not found")
-                continue
-
-            if "coordinator" not in hass.data[DOMAIN][entry_id]:
-                _LOGGER.warning("Coordinator not found")
-                continue
-
-            coordinator = hass.data[DOMAIN][entry_id]["coordinator"]
-            if coordinator.data is None:
-                _LOGGER.warning("No coordinator data")
-
-        if coordinator.data is None:
-            _LOGGER.warning("No coordinator data")
+        vin = next((ident[1] for ident in device.identifiers if ident[0] == DOMAIN), None)
+        if vin is None:
+            _LOGGER.warning("Device has no %s identifier", DOMAIN)
             return
 
-        for identifier in device.identifiers:
-            if identifier[0] == DOMAIN:
+        # A device can still list a config entry that's been unloaded but not removed (HA only
+        # drops an entry from a shared device's config_entries on full removal, not on unload),
+        # and with two Toyota accounts sharing a vehicle, a device can legitimately list an entry
+        # that has never had -- and will never have -- this VIN in its coordinator data (the
+        # losing side of a family-sharing claim). Resolve by finding whichever entry's
+        # coordinator actually has this VIN, instead of trusting the last-iterated entry_id.
+        coordinator = None
+        for entry_id in device.config_entries:
+            entry_runtime = hass.data.get(DOMAIN, {}).get(entry_id)
+            if not entry_runtime or "coordinator" not in entry_runtime:
+                continue
+            candidate = entry_runtime["coordinator"]
+            if candidate.data and any(v.vin == vin for v in candidate.data):
+                coordinator = candidate
+                break
 
-                vin = identifier[1]
-                for vehicle in coordinator.data:
-                    if vehicle.vin == vin and remote_action.upper() == "REFRESH" and vehicle.subscribed:
-                        await vehicle.poll_vehicle_refresh()
-                        # TODO: This works great and prevents us from unnecessarily hitting Toyota. But we can and should
-                        # probably do stuff like this in the library where we can better control which APIs we hit to refresh our in-memory data.
-                        coordinator.async_set_updated_data(coordinator.data)
-                        await asyncio.sleep(10)
-                        await coordinator.async_request_refresh()
-                    elif vehicle.vin == vin and vehicle.subscribed:
-                        command = COMMAND_MAP[remote_action]
-                        if not vehicle.supports_command(command):
-                            _LOGGER.warning(
-                                "Skipping %s for %s: Toyota reports this vehicle does not support this command",
-                                remote_action,
-                                vin,
-                            )
-                            break
-                        await vehicle.send_command(command)
-                        break
+        if coordinator is None:
+            _LOGGER.warning("No loaded config entry currently manages VIN ...%s", vin[-4:])
+            return
 
-                _LOGGER.info("Handling service call %s for %s ", remote_action, vin)
+        # REFRESH and every other command (lock, hazards, engine start/stop) are handled in one
+        # loop/if-elif rather than as separate functions because they share the vin-matching
+        # loop and the trailing log line -- REFRESH's branch is a different call path
+        # (poll_vehicle_refresh() + a manual coordinator nudge, see the TODO below) than the
+        # generic send_command() path every other service uses.
+        for vehicle in coordinator.data:
+            if vehicle.vin == vin and remote_action.upper() == "REFRESH" and vehicle.subscribed:
+                await vehicle.poll_vehicle_refresh()
+                # TODO: This works great and prevents us from unnecessarily hitting Toyota. But we can and should
+                # probably do stuff like this in the library where we can better control which APIs we hit to refresh our in-memory data.
+                # Same delayed-refresh pattern as button.py's ToyotaCommandButton/ToyotaRefreshButton --
+                # see the comments there for why the sleep and the extra async_set_updated_data exist.
+                coordinator.async_set_updated_data(coordinator.data)
+                await asyncio.sleep(10)
+                await coordinator.async_request_refresh()
+            elif vehicle.vin == vin and vehicle.subscribed:
+                command = COMMAND_MAP[remote_action]
+                if not vehicle.supports_command(command):
+                    _LOGGER.warning(
+                        "Skipping %s for %s: Toyota reports this vehicle does not support this command",
+                        remote_action,
+                        vin,
+                    )
+                    break
+                await vehicle.send_command(command)
+                break
 
+        _LOGGER.info("Handling service call %s for %s ", remote_action, vin)
         return
 
     hass.services.async_register(DOMAIN, ENGINE_START, async_service_handle)
@@ -185,6 +344,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         _LOGGER.exception(e)
         raise ConfigEntryAuthFailed(e) from e
 
+    # Reuse a stable device ID across restarts instead of letting a fresh one get generated
+    # every time. Without this, every HA restart (and every standalone script run during
+    # development) looks to Toyota like a brand new, never-before-seen device -- and Toyota's
+    # backend appears to cap how many concurrent devices can hold an active subscription per
+    # vehicle (see the "device limit exceeded?" handling in websocket_handler.py), so repeated
+    # restarts during development can plausibly exhaust that cap on their own.
+    if "device_id" in entry.data:
+        client.auth.set_device_id(entry.data["device_id"])
+    else:
+        entry_data = dict(entry.data)
+        entry_data["device_id"] = client.auth.get_device_id()
+        hass.config_entries.async_update_entry(entry, data=entry_data)
+
     coordinator = DataUpdateCoordinator(
         hass,
         _LOGGER,
@@ -192,35 +364,53 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         update_method=lambda: update_vehicles_status(hass, client, entry),
         update_interval=timedelta(seconds=UPDATE_INTERVAL),
     )
-    await coordinator.async_config_entry_first_refresh()
 
-    # Start WebSocket handler for vehicle status push notifications. Only for 21MM/24MM --
-    # 17CYPLUS is confirmed to work fully via REST alone (verified via live testing), so there's
-    # no reason to open a WebSocket connection for it. 21MM/24MM keep it as a fallback: this
-    # integration is used by vehicles we haven't personally tested, and REST working for our
-    # own 21MM vehicle (once account permissions and the value-shape parsing were fixed) isn't
-    # proof it's sufficient for every account/vehicle combination on this generation.
-    ws_handler = ToyotaWebSocketHandler(client)
-    vins = (
-        [
-            v.vin
-            for v in coordinator.data
-            if v.subscribed and v.api_generation != ApiVehicleGeneration.CY17PLUS.value
-        ]
-        if coordinator.data
-        else []
-    )
-    if vins:
-        await ws_handler.start(vins)
-    client._ws_handler = ws_handler
+    # From here on, this entry may end up holding VIN claims -- async_config_entry_first_refresh()
+    # below calls update_vehicles_status(), which claims vehicles as a side effect before it can
+    # fail on something unrelated later in the same call (e.g. writing the refreshed entry data).
+    # Anything that can still fail through the end of setup must release those claims on the way
+    # out -- otherwise a claim can outlive the entry that holds it, permanently blocking the
+    # vehicle from ever being claimed by another entry.
+    try:
+        await coordinator.async_config_entry_first_refresh()
 
-    hass.data[DOMAIN][entry.entry_id] = {
-        "toyota_na_client": client,
-        "coordinator": coordinator,
-        "ws_handler": ws_handler,
-    }
+        # Start WebSocket handler for vehicle status push notifications. Only for 21MM/24MM --
+        # 17CYPLUS is confirmed to work fully via REST alone (verified via live testing), so
+        # there's no reason to open a WebSocket connection for it. 21MM/24MM keep it as a
+        # fallback: this integration is used by vehicles we haven't personally tested, and REST
+        # working for our own 21MM vehicle (once account permissions and the value-shape parsing
+        # were fixed) isn't proof it's sufficient for every account/vehicle combination on this
+        # generation.
+        ws_handler = ToyotaWebSocketHandler(client)
+        vins = (
+            [
+                v.vin
+                for v in coordinator.data
+                if v.subscribed and v.api_generation != ApiVehicleGeneration.CY17PLUS.value
+            ]
+            if coordinator.data
+            else []
+        )
+        if vins:
+            await ws_handler.start(vins)
+        client._ws_handler = ws_handler
 
-    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+        hass.data[DOMAIN][entry.entry_id] = {
+            "toyota_na_client": client,
+            "coordinator": coordinator,
+            "ws_handler": ws_handler,
+            # Snapshot of the exclusion option as of this setup, so async_update_options() can
+            # tell an actual options-flow change apart from the routine entry.data writes
+            # (token refresh, last_refreshed_at) that also fire the update listener.
+            "excluded_vins_snapshot": set(entry.options.get(OPT_EXCLUDED_VINS, [])),
+        }
+
+        entry.async_on_unload(entry.add_update_listener(async_update_options))
+
+        await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    except Exception:
+        async_release_vehicle_claims(hass, entry)
+        raise
 
     return True
 
@@ -239,7 +429,25 @@ async def update_vehicles_status(hass: HomeAssistant, client: ToyotaOneClient, e
         need_refresh = True
     try:
         _LOGGER.debug("Updating vehicle status")
-        raw_vehicles = await get_vehicles(client)
+
+        # Only the user's explicit exclusions pre-filter get_vehicles() -- vehicles claimed by
+        # another entry are deliberately NOT pre-filtered here. async_claim_vehicles() below is
+        # the sole, unconditional authority on every refresh; letting it re-examine every VIN
+        # every cycle (rather than skipping ones lost last time) is what lets a losing entry
+        # keep re-asserting or clearing its own Repair issue as the conflict evolves.
+        user_excluded_vins = set(entry.options.get(OPT_EXCLUDED_VINS, []))
+        for vin in user_excluded_vins:
+            # An explicit exclusion resolves any prior conflict from this entry's side.
+            ir.async_delete_issue(hass, DOMAIN, _shared_vehicle_issue_id(vin, entry.entry_id))
+
+        fetched_vehicles = await get_vehicles(client, exclude_vins=user_excluded_vins)
+        raw_vehicles = async_claim_vehicles(hass, entry, fetched_vehicles)
+        # Vehicles this entry actually fetched (so we know they still exist on the account) but
+        # didn't win the claim for this cycle -- distinct from a vehicle simply missing from a
+        # possibly-incomplete fetch. See async_prune_unclaimed_devices() for why this distinction
+        # matters.
+        lost_to_conflict = {v.vin for v in fetched_vehicles} - {v.vin for v in raw_vehicles}
+
         vehicles: list[ToyotaVehicle] = []
         for vehicle in raw_vehicles:
             if vehicle.subscribed is not True:
@@ -257,6 +465,7 @@ async def update_vehicles_status(hass: HomeAssistant, client: ToyotaOneClient, e
                 except Exception as e:
                     _LOGGER.warning("Vehicle refresh failed (%s), continuing without refresh", e)
             vehicles.append(vehicle)
+        async_prune_unclaimed_devices(hass, entry, user_excluded_vins | lost_to_conflict)
         entry_data = dict(entry.data)
         if need_refresh:
             entry_data["last_refreshed_at"] = datetime.utcnow().timestamp()
@@ -285,5 +494,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id)
+        async_release_vehicle_claims(hass, entry)
 
     return unload_ok

--- a/custom_components/toyota_na/__init__.py
+++ b/custom_components/toyota_na/__init__.py
@@ -144,7 +144,15 @@ async def async_setup(hass: HomeAssistant, _processed_config) -> bool:
                         await asyncio.sleep(10)
                         await coordinator.async_request_refresh()
                     elif vehicle.vin == vin and vehicle.subscribed:
-                        await vehicle.send_command(COMMAND_MAP[remote_action])
+                        command = COMMAND_MAP[remote_action]
+                        if not vehicle.supports_command(command):
+                            _LOGGER.warning(
+                                "Skipping %s for %s: Toyota reports this vehicle does not support this command",
+                                remote_action,
+                                vin,
+                            )
+                            break
+                        await vehicle.send_command(command)
                         break
 
                 _LOGGER.info("Handling service call %s for %s ", remote_action, vin)

--- a/custom_components/toyota_na/__init__.py
+++ b/custom_components/toyota_na/__init__.py
@@ -194,9 +194,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     )
     await coordinator.async_config_entry_first_refresh()
 
-    # Start WebSocket handler for vehicle status push notifications (21MM+)
+    # Start WebSocket handler for vehicle status push notifications. Only for 21MM/24MM --
+    # 17CYPLUS is confirmed to work fully via REST alone (verified via live testing), so there's
+    # no reason to open a WebSocket connection for it. 21MM/24MM keep it as a fallback: this
+    # integration is used by vehicles we haven't personally tested, and REST working for our
+    # own 21MM vehicle (once account permissions and the value-shape parsing were fixed) isn't
+    # proof it's sufficient for every account/vehicle combination on this generation.
     ws_handler = ToyotaWebSocketHandler(client)
-    vins = [v.vin for v in coordinator.data if v.subscribed] if coordinator.data else []
+    vins = (
+        [v.vin for v in coordinator.data if v.subscribed and v.api_generation != "17CYPLUS"]
+        if coordinator.data
+        else []
+    )
     if vins:
         await ws_handler.start(vins)
     client._ws_handler = ws_handler

--- a/custom_components/toyota_na/__init__.py
+++ b/custom_components/toyota_na/__init__.py
@@ -202,7 +202,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     # proof it's sufficient for every account/vehicle combination on this generation.
     ws_handler = ToyotaWebSocketHandler(client)
     vins = (
-        [v.vin for v in coordinator.data if v.subscribed and v.api_generation != "17CYPLUS"]
+        [
+            v.vin
+            for v in coordinator.data
+            if v.subscribed and v.api_generation != ApiVehicleGeneration.CY17PLUS.value
+        ]
         if coordinator.data
         else []
     )

--- a/custom_components/toyota_na/base_entity.py
+++ b/custom_components/toyota_na/base_entity.py
@@ -44,6 +44,12 @@ class ToyotaNABaseEntity(CoordinatorEntity[list[ToyotaVehicle]]):
 
     @property
     def unique_id(self):
+        # Plain vin+sensor_name, no config-entry namespacing. A vehicle visible to two Toyota
+        # accounts (Toyota "family sharing") could in principle collide here if both accounts'
+        # entries tried to create entities for the same VIN -- that's prevented by only ever
+        # letting one config entry create entities for a given VIN in the first place (the VIN
+        # claim guard in __init__.py, see async_claim_vehicles()). That external invariant is
+        # what keeps this safe; it isn't enforced by anything in this file.
         return f"{self.vin}.{self.sensor_name}"
 
     @property

--- a/custom_components/toyota_na/base_entity.py
+++ b/custom_components/toyota_na/base_entity.py
@@ -31,7 +31,7 @@ class ToyotaNABaseEntity(CoordinatorEntity[list[ToyotaVehicle]]):
     @property
     def name(self):
         if self.vehicle is not None:
-            return f"{self.sensor_name} {self.device_info['name']}"
+            return self.sensor_name
 
     @property
     def unique_id(self):

--- a/custom_components/toyota_na/base_entity.py
+++ b/custom_components/toyota_na/base_entity.py
@@ -30,6 +30,15 @@ class ToyotaNABaseEntity(CoordinatorEntity[list[ToyotaVehicle]]):
 
     @property
     def name(self):
+        # Deliberately just the sensor name, not "{sensor_name} {vehicle model}" -- the manual
+        # concatenation this used to do produced confusing/doubled-looking names in the UI
+        # (e.g. a device page showing "2023 Highlander Front Driver Door 2023 Highlander").
+        # Note this class does NOT set `_attr_has_entity_name = True`, so Home Assistant isn't
+        # composing the device name in automatically either -- the friendly name really is just
+        # the bare sensor name (e.g. "Front Driver Door"), distinguished from the same sensor on
+        # another vehicle only by which device it's grouped under, not by the name itself.
+        # Migrating to has_entity_name=True (HA's modern entity-naming convention) would be a
+        # bigger, separate change -- it affects every existing entity_id.
         if self.vehicle is not None:
             return self.sensor_name
 

--- a/custom_components/toyota_na/binary_sensor.py
+++ b/custom_components/toyota_na/binary_sensor.py
@@ -12,6 +12,7 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
@@ -21,6 +22,16 @@ from .const import BINARY_SENSORS, DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 
+# Body styles that structurally cannot have a given feature, regardless of what any
+# particular API poll happens to report. Used to actively clean up entities that were
+# created once (e.g. under an older integration version) and then orphaned into permanent
+# "unavailable" once the code correctly stopped populating them -- Home Assistant doesn't
+# prune entities a platform silently stops providing, so without this they linger forever.
+_STRUCTURALLY_UNSUPPORTED_BACKDOOR_TYPES = {
+    VehicleFeatures.Trunk: {"tailgate"},
+}
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
@@ -28,6 +39,7 @@ async def async_setup_entry(
 ):
     """Set up the binary_sensor platform."""
     binary_sensors = []
+    registry = er.async_get(hass)
 
     coordinator: DataUpdateCoordinator[list[ToyotaVehicle]] = hass.data[DOMAIN][
         config_entry.entry_id
@@ -43,6 +55,23 @@ async def async_setup_entry(
                     continue
                 if vehicle.subscribed is False and cast(bool, entity_config["subscription"]):
                     continue
+
+                unsupported_backdoor_types = _STRUCTURALLY_UNSUPPORTED_BACKDOOR_TYPES.get(
+                    feature_sensor["feature"]
+                )
+                if unsupported_backdoor_types and vehicle.backdoor_type in unsupported_backdoor_types:
+                    stale_entity_id = registry.async_get_entity_id(
+                        "binary_sensor", DOMAIN, f"{vehicle.vin}.{entity_config['name']}"
+                    )
+                    if stale_entity_id:
+                        _LOGGER.info(
+                            "Removing %s: not applicable to this vehicle's body style (backdoorType=%s)",
+                            stale_entity_id,
+                            vehicle.backdoor_type,
+                        )
+                        registry.async_remove(stale_entity_id)
+                    continue
+
                 feature = vehicle.features.get(cast(VehicleFeatures, feature_sensor["feature"]))
                 if feature is None:
                     continue
@@ -122,4 +151,16 @@ class ToyotaBinarySensor(ToyotaNABaseEntity, BinarySensorEntity):
 
     @property
     def available(self):
-        return self.feature(self._vehicle_feature) is not None
+        sensor = self.feature(self._vehicle_feature)
+        if sensor is None:
+            return False
+        # Some API responses report lock state without reporting open/closed position
+        # (closed is None in that case). The DOOR-class reading has nothing to show then --
+        # surfacing it as unavailable is more honest than fabricating an "open" state.
+        if (
+            self.device_class == BinarySensorDeviceClass.DOOR
+            and isinstance(sensor, ToyotaOpening)
+            and sensor.closed is None
+        ):
+            return False
+        return True

--- a/custom_components/toyota_na/binary_sensor.py
+++ b/custom_components/toyota_na/binary_sensor.py
@@ -27,6 +27,13 @@ _LOGGER = logging.getLogger(__name__)
 # created once (e.g. under an older integration version) and then orphaned into permanent
 # "unavailable" once the code correctly stopped populating them -- Home Assistant doesn't
 # prune entities a platform silently stops providing, so without this they linger forever.
+#
+# Only Trunk/"tailgate" is listed because it's the only case actually confirmed via live
+# testing (a pickup truck's tailgate reports as `backdoor_type: "tailgate"`, and the API never
+# sends a Trunk feature value for it). Other body-style mismatches may well exist (e.g. no
+# moonroof, no rear doors on a 2-door) but haven't been observed/confirmed -- add an entry here
+# the same way, keyed by whatever `backdoor_type` (or other vehicle attribute) value structurally
+# rules the feature out, once one is confirmed.
 _STRUCTURALLY_UNSUPPORTED_BACKDOOR_TYPES = {
     VehicleFeatures.Trunk: {"tailgate"},
 }
@@ -60,8 +67,14 @@ async def async_setup_entry(
                     feature_sensor["feature"]
                 )
                 if unsupported_backdoor_types and vehicle.backdoor_type in unsupported_backdoor_types:
+                    # Rebuilds ToyotaNABaseEntity.unique_id's format (base_entity.py) by hand,
+                    # since there's no entity object here yet to ask -- if that format ever
+                    # changes, this must change with it or stale-entity cleanup silently stops
+                    # matching anything.
                     stale_entity_id = registry.async_get_entity_id(
-                        "binary_sensor", DOMAIN, f"{vehicle.vin}.{entity_config['name']}"
+                        "binary_sensor",
+                        DOMAIN,
+                        f"{vehicle.vin}.{entity_config['name']}",
                     )
                     if stale_entity_id:
                         _LOGGER.info(

--- a/custom_components/toyota_na/button.py
+++ b/custom_components/toyota_na/button.py
@@ -1,0 +1,137 @@
+import asyncio
+from typing import Any, cast
+
+from toyota_na.vehicle.base_vehicle import RemoteRequestCommand, ToyotaVehicle
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from .base_entity import ToyotaNABaseEntity
+from .const import COMMAND_BUTTONS, DOMAIN
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_devices: AddEntitiesCallback,
+):
+    """Set up the button platform."""
+    buttons = []
+
+    coordinator: DataUpdateCoordinator[list[ToyotaVehicle]] = hass.data[DOMAIN][
+        config_entry.entry_id
+    ]["coordinator"]
+
+    for vehicle in coordinator.data:
+        if vehicle.subscribed is False:
+            continue
+
+        for button_config in COMMAND_BUTTONS:
+            command = cast(RemoteRequestCommand, button_config["command"])
+            # Vehicles that don't support a command (per Toyota's remoteServiceCapabilities,
+            # e.g. hazards on a truck without that capability) never get the button entity
+            # created at all, rather than creating it and marking it unavailable/disabled. This
+            # keeps a vehicle's dashboard free of buttons that can never work for it, at the
+            # cost of the button not reappearing on its own if Toyota later reports the
+            # capability as supported -- that would need a reload to pick up.
+            if not vehicle.supports_command(command):
+                continue
+            buttons.append(
+                ToyotaCommandButton(
+                    command,
+                    cast(str, button_config["icon"]),
+                    coordinator,
+                    button_config["name"],
+                    vehicle.vin,
+                )
+            )
+
+        buttons.append(
+            ToyotaRefreshButton(
+                coordinator,
+                "Refresh",
+                vehicle.vin,
+            )
+        )
+
+    async_add_devices(buttons, True)
+
+
+class ToyotaCommandButton(ToyotaNABaseEntity, ButtonEntity):
+    _icon: str
+    _command: RemoteRequestCommand
+
+    def __init__(
+        self,
+        command: RemoteRequestCommand,
+        icon: str,
+        *args: Any,
+    ):
+        super().__init__(*args)
+        self._command = command
+        self._icon = icon
+
+    @property
+    def icon(self):
+        return self._icon
+
+    @property
+    def available(self):
+        return self.vehicle is not None
+
+    async def async_press(self) -> None:
+        """Send the remote command, then refresh the coordinator once the vehicle updates."""
+        if self.vehicle is None:
+            return
+        await self.vehicle.send_command(self._command)
+        self.hass.async_create_task(self._background_refresh())
+
+    async def _background_refresh(self):
+        """Poll for updated vehicle state after a command, then refresh the coordinator.
+
+        The 10-second sleep gives Toyota's backend time to actually process the command and the
+        vehicle time to report its new state before we ask for it -- polling immediately tends
+        to just re-fetch the pre-command state. Runs as a fire-and-forget background task (see
+        async_press()) so the button press itself returns immediately rather than blocking on
+        this; failures here are swallowed rather than raised because there's nothing meaningful
+        to surface for a background poll -- the command itself already succeeded or failed on
+        its own, and the next scheduled coordinator refresh will pick up the real state
+        regardless. Mirrors the same pattern used for the REFRESH service in __init__.py's
+        async_service_handle -- see the TODO there for the same reasoning, and consider fixing
+        both places together if this ever moves into the library.
+        """
+        try:
+            await self.vehicle.poll_vehicle_refresh()
+            await asyncio.sleep(10)
+            await self.coordinator.async_request_refresh()
+        except Exception:
+            pass
+
+
+class ToyotaRefreshButton(ToyotaNABaseEntity, ButtonEntity):
+    @property
+    def icon(self):
+        return "mdi:refresh"
+
+    @property
+    def available(self):
+        return self.vehicle is not None
+
+    async def async_press(self) -> None:
+        """Force Toyota to push a fresh status, then refresh the coordinator.
+
+        The async_set_updated_data() call re-pushes the coordinator's *existing* data -- it
+        looks like a no-op, but its purpose is to make every entity re-evaluate right away (e.g.
+        pick up this button's own state/attributes changing) rather than wait for the real
+        refresh below, which is deliberately delayed. See _background_refresh() on
+        ToyotaCommandButton above for why the delay exists.
+        """
+        if self.vehicle is None:
+            return
+        await self.vehicle.poll_vehicle_refresh()
+        self.coordinator.async_set_updated_data(self.coordinator.data)
+        await asyncio.sleep(10)
+        await self.coordinator.async_request_refresh()

--- a/custom_components/toyota_na/config_flow.py
+++ b/custom_components/toyota_na/config_flow.py
@@ -1,6 +1,8 @@
 import logging
 
 from homeassistant import config_entries
+from homeassistant.core import callback
+from homeassistant.helpers import config_validation as cv
 import voluptuous as vol
 
 from toyota_na import ToyotaOneAuth, ToyotaOneClient
@@ -12,13 +14,19 @@ ToyotaOneAuth.authorize = authorize
 ToyotaOneAuth.login = login
 import json
 
-from .const import DOMAIN
+from .const import CONF_MANAGED_VINS, DOMAIN, OPT_EXCLUDED_VINS
+from .patch_base_vehicle import ApiVehicleGeneration
 
 _LOGGER = logging.getLogger(__name__)
 
 
 class ToyotaNAConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Config flow for Toyota (North America) connected services"""
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        return ToyotaNAOptionsFlow()
 
     async def async_step_user(self, user_input=None):
         errors = {}
@@ -91,3 +99,59 @@ class ToyotaNAConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_reauth(self, data):
         return await self.async_step_user()
+
+
+class ToyotaNAOptionsFlow(config_entries.OptionsFlow):
+    """Lets a config entry's account exclude specific vehicles it can see.
+
+    Mainly for accounts that share a vehicle with another Toyota account (Toyota "family
+    sharing") that's also set up as its own config entry in this Home Assistant instance --
+    excluding the shared vehicle here lets the other account's entry manage it instead, without
+    the two entries ever contending over the same vehicle (see async_claim_vehicles() in
+    __init__.py, which enforces this even if a vehicle isn't explicitly excluded here).
+    """
+
+    async def async_step_init(self, user_input=None):
+        entry_data = self.hass.data.get(DOMAIN, {}).get(self.config_entry.entry_id)
+        client = entry_data.get("toyota_na_client") if entry_data else None
+        if client is None:
+            # The entry has to actually be loaded (logged in) for us to have a client to ask
+            # Toyota for this account's vehicle list.
+            return self.async_abort(reason="entry_not_loaded")
+
+        try:
+            api_vehicles = await client.get_user_vehicle_list()
+        except Exception:
+            _LOGGER.exception("Failed to fetch vehicle list for options flow")
+            return self.async_abort(reason="cannot_fetch_vehicles")
+
+        supported_generations = {item.value for item in ApiVehicleGeneration}
+        vehicle_choices = {
+            v["vin"]: f"{v.get('modelYear', '')} {v.get('modelName', v['vin'])}".strip()
+            for v in api_vehicles
+            if "vin" in v and v.get("generation") in supported_generations
+        }
+
+        if not vehicle_choices:
+            return self.async_abort(reason="no_vehicles")
+
+        if user_input is not None:
+            managed = set(user_input.get(CONF_MANAGED_VINS, []))
+            excluded_vins = [vin for vin in vehicle_choices if vin not in managed]
+            return self.async_create_entry(
+                title="", data={OPT_EXCLUDED_VINS: excluded_vins}
+            )
+
+        currently_excluded = set(self.config_entry.options.get(OPT_EXCLUDED_VINS, []))
+        default_managed = [vin for vin in vehicle_choices if vin not in currently_excluded]
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_MANAGED_VINS, default=default_managed
+                    ): cv.multi_select(vehicle_choices),
+                }
+            ),
+        )

--- a/custom_components/toyota_na/const.py
+++ b/custom_components/toyota_na/const.py
@@ -20,6 +20,20 @@ REFRESH = "refresh"
 UPDATE_INTERVAL = 600
 REFRESH_STATUS_INTERVAL = 2 * 3600
 
+# hass.data[DOMAIN][VIN_CLAIMS] is a shared {vin: entry_id} map, used so that a vehicle visible
+# to two Toyota accounts (e.g. Toyota "family sharing") is only ever managed by one config entry
+# at a time -- see async_claim_vehicles()/async_release_vehicle_claims() in __init__.py.
+VIN_CLAIMS = "vin_claims"
+
+# entry.options key: list of VINs a config entry has been told NOT to manage, even though its
+# Toyota account can see them. Set via the integration's Configure (options) flow. Absent/empty
+# means "manage every vehicle this account can see", which is today's behavior unchanged.
+OPT_EXCLUDED_VINS = "excluded_vins"
+
+# Options flow form field name for the vehicle picker (inverse of OPT_EXCLUDED_VINS -- the user
+# picks what TO manage, which gets inverted to an exclusion list before saving).
+CONF_MANAGED_VINS = "managed_vins"
+
 COMMAND_MAP = {
     DOOR_LOCK: RemoteRequestCommand.DoorLock,
     DOOR_UNLOCK: RemoteRequestCommand.DoorUnlock,

--- a/custom_components/toyota_na/const.py
+++ b/custom_components/toyota_na/const.py
@@ -30,6 +30,42 @@ COMMAND_MAP = {
     REFRESH: RemoteRequestCommand.Refresh,
 }
 
+# door_lock/door_unlock are deliberately excluded -- the `lock` platform already provides
+# native Lock/Unlock controls for those via the vehicle's Lock entity, so a button would
+# just be redundant. Refresh isn't here either; it needs a different call path
+# (poll_vehicle_refresh(), not send_command()) so it's handled as its own entity class.
+#
+# HazardsOff is deliberately excluded too, unlike every other on/off pair here. Toyota's API
+# accepts a distinct "hazard-off" command (it's not an alias of "hazard-on" -- see
+# RemoteRequestCommand/the generation-specific command maps in patch_seventeen_cy(_plus).py),
+# but live testing showed pressing it has no observable effect on the vehicle, matching the
+# Toyota app's own behavior (hazards there are momentary -- they turn on and auto-stop after
+# ~60s, with no manual "off" available even from Toyota's own app). Best guess: Toyota's
+# remote-hazards feature is on/timeout-off only, and the cloud API silently accepts an "off"
+# request it doesn't actually act on. HazardsOn is kept since turning hazards on remotely is a
+# real, working, useful command. The pre-existing hazards_off service (see COMMAND_MAP above,
+# unrelated to this button list) is left as-is for automations, since this hasn't been proven
+# broken for every vehicle/account -- just never proven working -- and a service is a smaller,
+# opt-in surface than a dashboard button a normal user clicks and is left wondering why nothing
+# happened.
+COMMAND_BUTTONS = [
+    {
+        "command": RemoteRequestCommand.EngineStart,
+        "icon": "mdi:engine-outline",
+        "name": "Remote Start",
+    },
+    {
+        "command": RemoteRequestCommand.EngineStop,
+        "icon": "mdi:engine-off-outline",
+        "name": "Remote Stop",
+    },
+    {
+        "command": RemoteRequestCommand.HazardsOn,
+        "icon": "mdi:hazard-lights",
+        "name": "Hazards On",
+    },
+]
+
 BINARY_SENSORS = [
     {
         "device_class": BinarySensorDeviceClass.DOOR,

--- a/custom_components/toyota_na/diagnostics.py
+++ b/custom_components/toyota_na/diagnostics.py
@@ -53,6 +53,11 @@ async def async_get_config_entry_diagnostics(
     for (i, vehicle) in enumerate(user_vehicle_list):
         vin=vehicle["vin"]
 
+        # Collapses three raw API generations (17CYPLUS/21MM/24MM) into one, since they're all
+        # handled by the same vehicle class and endpoints -- same collapse patch_vehicle.py does
+        # via ApiVehicleGeneration when constructing vehicle objects, just re-derived here by
+        # hand instead of reusing that enum, since this file talks to the client directly
+        # without going through a vehicle object at all.
         if (vehicle["generation"] == "17CYPLUS" or vehicle["generation"] == "21MM"  or vehicle["generation"] == "24MM"):
             generation = "17CYPLUS"
         elif vehicle["generation"] == "17CY":

--- a/custom_components/toyota_na/diagnostics.py
+++ b/custom_components/toyota_na/diagnostics.py
@@ -64,7 +64,9 @@ async def async_get_config_entry_diagnostics(
             pass
 
         try:
-            user_telemetry = await client.get_telemetry(vin, generation)
+            user_telemetry = await client.get_telemetry(
+                vin, region=vehicle.get("region", "US"), generation=generation
+            )
         except Exception:
             pass
 

--- a/custom_components/toyota_na/patch_base_vehicle.py
+++ b/custom_components/toyota_na/patch_base_vehicle.py
@@ -106,6 +106,7 @@ class ToyotaVehicle(ABC):
     _region: str
     _backdoor_type: Union[str, None]
     _capabilities: dict
+    _api_generation: Union[str, None]
 
     # Maps a command to the remoteServiceCapabilities flag that indicates whether Toyota
     # reports this vehicle as actually supporting it. Commands with no entry here (e.g.
@@ -131,6 +132,7 @@ class ToyotaVehicle(ABC):
         generation: ApiVehicleGeneration,
         backdoor_type: Union[str, None] = None,
         capabilities: Union[dict, None] = None,
+        api_generation: Union[str, None] = None,
     ):
         """
         Initialize a new vehicle object. Must call `vehicle.update()` to fully populate the object.
@@ -142,6 +144,11 @@ class ToyotaVehicle(ABC):
         :param capabilities: The vehicle's remoteServiceCapabilities dict from the Toyota API,
             used to avoid sending remote commands Toyota has already told us this vehicle
             doesn't support (e.g. hazards on trucks that lack that capability).
+        :param api_generation: The raw generation string from the vehicle-list API response
+            (e.g. "17CYPLUS", "21MM", "24MM") -- distinct from `generation`, which several raw
+            API generations are deliberately collapsed into for a single vehicle-generation
+            class. Needed anywhere code cares which of those raw generations a vehicle actually
+            is, e.g. deciding whether it needs the AppSync WebSocket subscription.
         """
 
         self._features = {}
@@ -155,6 +162,7 @@ class ToyotaVehicle(ABC):
         self._region = region
         self._backdoor_type = backdoor_type
         self._capabilities = capabilities or {}
+        self._api_generation = api_generation
 
     @abstractmethod
     async def poll_vehicle_refresh(self) -> None:
@@ -219,6 +227,10 @@ class ToyotaVehicle(ABC):
     @property
     def capabilities(self):
         return self._capabilities
+
+    @property
+    def api_generation(self):
+        return self._api_generation
 
     def supports_command(self, command: "RemoteRequestCommand") -> bool:
         """Whether Toyota's reported remoteServiceCapabilities say this vehicle supports

--- a/custom_components/toyota_na/patch_base_vehicle.py
+++ b/custom_components/toyota_na/patch_base_vehicle.py
@@ -104,6 +104,20 @@ class ToyotaVehicle(ABC):
     _generation: ApiVehicleGeneration
     _vin: str
     _region: str
+    _backdoor_type: Union[str, None]
+    _capabilities: dict
+
+    # Maps a command to the remoteServiceCapabilities flag that indicates whether Toyota
+    # reports this vehicle as actually supporting it. Commands with no entry here (e.g.
+    # Refresh) are always considered supported.
+    _COMMAND_CAPABILITY_MAP = {
+        RemoteRequestCommand.DoorLock: "dlockUnlockCapable",
+        RemoteRequestCommand.DoorUnlock: "dlockUnlockCapable",
+        RemoteRequestCommand.EngineStart: "estartEnabled",
+        RemoteRequestCommand.EngineStop: "estopEnabled",
+        RemoteRequestCommand.HazardsOn: "hazardCapable",
+        RemoteRequestCommand.HazardsOff: "hazardCapable",
+    }
 
     def __init__(
         self,
@@ -115,11 +129,19 @@ class ToyotaVehicle(ABC):
         vin: str,
         region: str,
         generation: ApiVehicleGeneration,
+        backdoor_type: Union[str, None] = None,
+        capabilities: Union[dict, None] = None,
     ):
         """
         Initialize a new vehicle object. Must call `vehicle.update()` to fully populate the object.
 
         :param vin: Vehicle identification number
+        :param backdoor_type: The vehicle's actual rear cargo access type as reported by the
+            Toyota API (e.g. "hatch", "tailgate", "trunk"). Used for GraphQL calls that require
+            this capability to be declared accurately.
+        :param capabilities: The vehicle's remoteServiceCapabilities dict from the Toyota API,
+            used to avoid sending remote commands Toyota has already told us this vehicle
+            doesn't support (e.g. hazards on trucks that lack that capability).
         """
 
         self._features = {}
@@ -131,6 +153,8 @@ class ToyotaVehicle(ABC):
         self._model_year = model_year
         self._vin = vin
         self._region = region
+        self._backdoor_type = backdoor_type
+        self._capabilities = capabilities or {}
 
     @abstractmethod
     async def poll_vehicle_refresh(self) -> None:
@@ -187,6 +211,25 @@ class ToyotaVehicle(ABC):
     @property
     def vin(self):
         return self._vin
+
+    @property
+    def backdoor_type(self):
+        return self._backdoor_type
+
+    @property
+    def capabilities(self):
+        return self._capabilities
+
+    def supports_command(self, command: "RemoteRequestCommand") -> bool:
+        """Whether Toyota's reported remoteServiceCapabilities say this vehicle supports
+        the given command. Commands with no known capability flag, or capability data we
+        don't have, default to True — we only want to block commands we can positively
+        confirm are unsupported (e.g. hazards on a truck that lacks that capability),
+        not silently swallow commands just because we're missing data."""
+        capability_key = self._COMMAND_CAPABILITY_MAP.get(command)
+        if capability_key is None or capability_key not in self._capabilities:
+            return True
+        return bool(self._capabilities[capability_key])
 
     def __repr__(self):
         str = f"{self.__class__.__name__}(\n    features=(\n"

--- a/custom_components/toyota_na/patch_client.py
+++ b/custom_components/toyota_na/patch_client.py
@@ -21,9 +21,9 @@ GRAPHQL_PRE_WAKE = """mutation SendPreWakeCommand($guid: String!) {
   }
 }"""
 
-GRAPHQL_CONFIRM_SUBSCRIPTION = """mutation ConfirmSubscriptionStatus($vin: String!) {
+GRAPHQL_CONFIRM_SUBSCRIPTION = """mutation ConfirmSubscriptionStatus($vin: String!, $backdoorType: String!) {
   confirmSubscriptionActive(vin: $vin, payload: {
-    vehicleCapabilities: { backdoorType: "hatch" }
+    vehicleCapabilities: { backdoorType: $backdoorType }
   }) { vin }
 }"""
 
@@ -99,10 +99,18 @@ async def send_refresh_request_17cyplus(self, vin):
 
 async def remote_request_17cyplus(self, vin, command):
     """Remote command (lock, unlock, engine start, etc.) via v1/global/remote."""
-    return await self.api_post(
+    response = await self.api_post(
         "v1/global/remote/command", {"command": command},
         {"VIN": vin, "X-BRAND": "T", "x-region": "US"}
     )
+    # Logged unconditionally (not just on HTTP error) because a "successful" response can
+    # still contain an embedded error/job-status Toyota expects the caller to check -- the
+    # existing api_request() only logs on HTTP >= 400, which tells us nothing when a command
+    # is silently ignored by the vehicle despite Toyota's cloud accepting the request.
+    _LOGGER.debug(
+        "Remote command '%s' for VIN ...%s response: %s", command, vin[-4:], response
+    )
+    return response
 
 async def get_vehicle_status_17cy(self, vin):
     """Legacy vehicle status."""
@@ -215,9 +223,18 @@ async def graphql_pre_wake(self, guid):
     return await self.graphql_request("SendPreWakeCommand", GRAPHQL_PRE_WAKE, {"guid": guid})
 
 
-async def graphql_confirm_subscription(self, vin):
-    """Confirm subscription is active for this VIN."""
-    return await self.graphql_request("ConfirmSubscriptionStatus", GRAPHQL_CONFIRM_SUBSCRIPTION, {"vin": vin})
+async def graphql_confirm_subscription(self, vin, backdoor_type=None):
+    """Confirm subscription is active for this VIN.
+
+    backdoor_type should be the vehicle's actual rear cargo access type from the Toyota API
+    (e.g. "hatch", "tailgate", "trunk"). Falls back to "hatch" if unknown, matching prior
+    hardcoded behavior, so callers that don't have this data yet don't regress.
+    """
+    return await self.graphql_request(
+        "ConfirmSubscriptionStatus",
+        GRAPHQL_CONFIRM_SUBSCRIPTION,
+        {"vin": vin, "backdoorType": backdoor_type or "hatch"},
+    )
 
 
 async def graphql_refresh_status(self, vin):

--- a/custom_components/toyota_na/patch_client.py
+++ b/custom_components/toyota_na/patch_client.py
@@ -106,7 +106,10 @@ async def remote_request_17cyplus(self, vin, command):
     # Logged unconditionally (not just on HTTP error) because a "successful" response can
     # still contain an embedded error/job-status Toyota expects the caller to check -- the
     # existing api_request() only logs on HTTP >= 400, which tells us nothing when a command
-    # is silently ignored by the vehicle despite Toyota's cloud accepting the request.
+    # is silently ignored by the vehicle despite Toyota's cloud accepting the request. Logs the
+    # full raw response body, not just a status/error field -- debug-level only (never enabled
+    # by default), but worth checking this response can't ever carry anything sensitive before
+    # broadening what triggers debug logging here or elsewhere in this module.
     _LOGGER.debug(
         "Remote command '%s' for VIN ...%s response: %s", command, vin[-4:], response
     )
@@ -228,7 +231,13 @@ async def graphql_confirm_subscription(self, vin, backdoor_type=None):
 
     backdoor_type should be the vehicle's actual rear cargo access type from the Toyota API
     (e.g. "hatch", "tailgate", "trunk"). Falls back to "hatch" if unknown, matching prior
-    hardcoded behavior, so callers that don't have this data yet don't regress.
+    hardcoded behavior, so callers that don't have this data yet don't regress. "hatch" isn't
+    known to be safe for every vehicle -- it's just what this code always sent before
+    backdoor_type was threaded through, so every caller already exercised that value without
+    apparent issue. A vehicle where "hatch" is actually wrong wouldn't necessarily be obvious
+    from this call alone (see the "no door/lock/hood/trunk status" warning in
+    patch_seventeen_cy_plus.py's update() for one symptom that could, among other causes,
+    stem from this).
     """
     return await self.graphql_request(
         "ConfirmSubscriptionStatus",

--- a/custom_components/toyota_na/patch_seventeen_cy.py
+++ b/custom_components/toyota_na/patch_seventeen_cy.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+from typing import Union
 
 from toyota_na.client import ToyotaOneClient
 from toyota_na.vehicle.base_vehicle import (
@@ -67,7 +68,6 @@ class SeventeenCYToyotaVehicle(ToyotaVehicle):
         "spareTirePressure": VehicleFeatures.SpareTirePressure,
         "tripA": VehicleFeatures.TripDetailsA,
         "tripB": VehicleFeatures.TripDetailsB,
-        "vehicleLocation": VehicleFeatures.ParkingLocation,
         "nextService": VehicleFeatures.NextService,
         "speed": VehicleFeatures.Speed,
     }
@@ -98,7 +98,22 @@ class SeventeenCYToyotaVehicle(ToyotaVehicle):
         )
 
     async def update(self):
-        
+
+        # Telemetry is parsed first, vehicle_status second, deliberately -- both report
+        # window/moonroof state, and vehicle_status is the fresher/more authoritative source
+        # for those when it includes them at all (confirmed by direct physical test on the
+        # 17CYPLUS-class code path; same map/parsing pattern applies here). vehicle_status
+        # running second means it overwrites telemetry's value when it has one, and leaves
+        # telemetry's value in place on polls where vehicle_status doesn't report window state.
+        try:
+            # telemetry
+            telemetry = await self._client.get_telemetry(self._vin, self._region, self._generation.value)
+            if telemetry:
+                self._parse_telemetry(telemetry)
+        except Exception as e:
+            _LOGGER.debug("Error parsing telemetry: %s", e)
+            pass
+
         try:
             if self._has_remote_subscription:
                 # vehicle_health_status
@@ -109,15 +124,6 @@ class SeventeenCYToyotaVehicle(ToyotaVehicle):
                     self._parse_vehicle_status(vehicle_status)
         except Exception as e:
             _LOGGER.debug("Error parsing vehicle status: %s", e)
-            pass
-
-        try:
-            # telemetry
-            telemetry = await self._client.get_telemetry(self._vin, self._region, self._generation.value)
-            if telemetry:
-                self._parse_telemetry(telemetry)
-        except Exception as e:
-            _LOGGER.debug("Error parsing telemetry: %s", e)
             pass
 
         try:
@@ -208,17 +214,36 @@ class SeventeenCYToyotaVehicle(ToyotaVehicle):
     # vehicle_health_status
     #
 
-    def _isClosed(self, section) -> bool:
+    # Position words mean the value reports open/closed state; lock words mean it reports
+    # lock state instead. Some generations report only a single lock-state value with no
+    # position at all, where older shapes report position first, then lock state.
+    _POSITION_VALUES = ("closed", "open", "opened")
+    _LOCK_STATE_VALUES = ("locked", "unlocked")
+
+    def _isClosed(self, section) -> Union[bool, None]:
+        """Whether the section reports a closed/open position. Returns None if position
+        isn't reported at all (e.g. a single lock-state-only value)."""
         values = section.get("values", [])
         if not values:
             return False
-        return values[0].get("value", "").lower() == "closed"
+        first_val = values[0].get("value", "").lower()
+        if first_val in self._LOCK_STATE_VALUES:
+            return None
+        return first_val == "closed"
 
-    def _isLocked(self, section) -> bool:
+    def _isLocked(self, section) -> Union[bool, None]:
+        """Whether the section reports lock state, as either the second value entry
+        (older shape) or the only value entry (newer shape). Returns None if lock state
+        isn't reported at all."""
         values = section.get("values", [])
-        if len(values) < 2:
-            return False
-        return values[1].get("value", "").lower() == "locked"
+        if not values:
+            return None
+        first_val = values[0].get("value", "").lower()
+        if len(values) == 1 and first_val in self._LOCK_STATE_VALUES:
+            return first_val == "locked"
+        if len(values) >= 2:
+            return values[1].get("value", "").lower() == "locked"
+        return None
 
     def _parse_vehicle_status(self, vehicle_status: dict) -> None:
         if not vehicle_status:
@@ -248,18 +273,23 @@ class SeventeenCYToyotaVehicle(ToyotaVehicle):
                 # We don't support all features necessarily. So avoid throwing on a key error.
                 if self._vehicle_status_category_map.get(key) is not None:
                     values = section.get("values", [])
-                    # CLOSED is always the first value entry. So we can use it to determine which subtype to instantiate
-                    if len(values) == 1:
+                    if not values:
+                        continue
+                    first_val = values[0].get("value", "").lower()
+                    if first_val not in self._POSITION_VALUES + self._LOCK_STATE_VALUES:
+                        continue
+
+                    closed = self._isClosed(section)
+                    locked = self._isLocked(section)
+
+                    if locked is not None:
                         self._features[
                             self._vehicle_status_category_map[key]
-                        ] = ToyotaOpening(self._isClosed(section))
-                    elif len(values) >= 2:
+                        ] = ToyotaLockableOpening(closed=closed, locked=locked)
+                    elif closed is not None:
                         self._features[
                             self._vehicle_status_category_map[key]
-                        ] = ToyotaLockableOpening(
-                            closed=self._isClosed(section),
-                            locked=self._isLocked(section),
-                        )
+                        ] = ToyotaOpening(closed=closed)
 
     #
     # get_telemetry
@@ -288,11 +318,14 @@ class SeventeenCYToyotaVehicle(ToyotaVehicle):
                 self._features[VehicleFeatures.FuelLevel] = ToyotaNumeric(value, "%")
                 continue
 
-            # vehicle_location has a different shape and different target entity class
+            # vehicle_location has a different shape and different target entity class.
+            # Toyota's own API labels this field "Last Parked", and it's the only location
+            # telemetry provides, so it backs both RealTimeLocation and ParkingLocation
+            # (the latter is otherwise only available via REST, which isn't always reachable).
             if key == "vehicleLocation":
-                self._features[VehicleFeatures.RealTimeLocation] = ToyotaLocation(
-                    value.get("latitude"), value.get("longitude")
-                )
+                location = ToyotaLocation(value.get("latitude"), value.get("longitude"))
+                self._features[VehicleFeatures.RealTimeLocation] = location
+                self._features[VehicleFeatures.ParkingLocation] = location
                 continue
 
             if self._vehicle_telemetry_map.get(key) is not None:

--- a/custom_components/toyota_na/patch_seventeen_cy.py
+++ b/custom_components/toyota_na/patch_seventeen_cy.py
@@ -216,7 +216,9 @@ class SeventeenCYToyotaVehicle(ToyotaVehicle):
 
     # Position words mean the value reports open/closed state; lock words mean it reports
     # lock state instead. Some generations report only a single lock-state value with no
-    # position at all, where older shapes report position first, then lock state.
+    # position at all, where older shapes report position first, then lock state. Reverse-
+    # engineered from live payloads (see the identical constants/comment in
+    # patch_seventeen_cy_plus.py), not from Toyota documentation.
     _POSITION_VALUES = ("closed", "open", "opened")
     _LOCK_STATE_VALUES = ("locked", "unlocked")
 
@@ -276,6 +278,9 @@ class SeventeenCYToyotaVehicle(ToyotaVehicle):
                     if not values:
                         continue
                     first_val = values[0].get("value", "").lower()
+                    # Deliberate: an unrecognized first value means skip this section for this
+                    # poll, leaving any existing feature value from a prior poll in place (see
+                    # the identical choice in patch_seventeen_cy_plus.py).
                     if first_val not in self._POSITION_VALUES + self._LOCK_STATE_VALUES:
                         continue
 

--- a/custom_components/toyota_na/patch_seventeen_cy_plus.py
+++ b/custom_components/toyota_na/patch_seventeen_cy_plus.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+from typing import Union
 
 from toyota_na.client import ToyotaOneClient
 from toyota_na.vehicle.base_vehicle import (
@@ -59,7 +60,6 @@ class SeventeenCYPlusToyotaVehicle(ToyotaVehicle):
         "spareTirePressure": VehicleFeatures.SpareTirePressure,
         "tripA": VehicleFeatures.TripDetailsA,
         "tripB": VehicleFeatures.TripDetailsB,
-        "vehicleLocation": VehicleFeatures.ParkingLocation,
         "nextService": VehicleFeatures.NextService,
         "speed": VehicleFeatures.Speed,
 
@@ -79,6 +79,8 @@ class SeventeenCYPlusToyotaVehicle(ToyotaVehicle):
         model_year: str,
         vin: str,
         region: str,
+        backdoor_type: str = None,
+        capabilities: dict = None,
     ):
         self._has_remote_subscription = has_remote_subscription
         self._has_electric = has_electric
@@ -93,11 +95,29 @@ class SeventeenCYPlusToyotaVehicle(ToyotaVehicle):
             vin,
             region,
             ApiVehicleGeneration.CY17PLUS,
+            backdoor_type,
+            capabilities,
         )
 
     _last_graphql_status = None  # persist last successful GraphQL status
 
     async def update(self):
+
+        # Telemetry is parsed first, vehicle_status second, deliberately -- both report
+        # window/moonroof state, and vehicle_status is the fresher/more authoritative source
+        # for those when it includes them at all (confirmed by direct physical test: a window
+        # left open was correctly reported "Open" by vehicle_status but incorrectly reported
+        # closed by telemetry for the same poll). vehicle_status running second means it
+        # overwrites telemetry's value when it has one, and simply leaves telemetry's value in
+        # place on the (common) polls where vehicle_status doesn't report window state at all.
+        try:
+            # telemetry
+            telemetry = await self._client.get_telemetry(self._vin, self._region)
+            if telemetry:
+                self._parse_telemetry(telemetry)
+        except Exception as e:
+            _LOGGER.debug("Error fetching telemetry: %s", e)
+            pass
 
         try:
             if self._has_remote_subscription:
@@ -111,22 +131,23 @@ class SeventeenCYPlusToyotaVehicle(ToyotaVehicle):
 
                 # WebSocket cached data (if available) provides additional detail
                 ws_handler = getattr(self._client, '_ws_handler', None)
-                if ws_handler:
-                    ws_status = ws_handler.get_cached_status(self._vin)
-                    if ws_status and ws_status.get("vehicleState"):
-                        self._last_graphql_status = ws_status
-                        self._parse_graphql_vehicle_status(ws_status)
+                ws_status = ws_handler.get_cached_status(self._vin) if ws_handler else None
+                if ws_status and ws_status.get("vehicleState"):
+                    self._last_graphql_status = ws_status
+                    self._parse_graphql_vehicle_status(ws_status)
+
+                if not vehicle_status and not self._last_vehicle_status and not ws_status:
+                    _LOGGER.warning(
+                        "No door/lock/hood/trunk status available for VIN ...%s, even though "
+                        "this vehicle has an active remote services subscription. If this "
+                        "persists, check whether this Toyota account is set as the primary "
+                        "remote-services driver for this vehicle -- Toyota returns empty "
+                        "responses to accounts that only have family-shared/guest access, "
+                        "even when the subscription itself is active.",
+                        self._vin[-4:],
+                    )
         except Exception as e:
             _LOGGER.debug("Error fetching vehicle status: %s", e)
-            pass
-
-        try:
-            # telemetry
-            telemetry = await self._client.get_telemetry(self._vin, self._region)
-            if telemetry:
-                self._parse_telemetry(telemetry)
-        except Exception as e:
-            _LOGGER.debug("Error fetching telemetry: %s", e)
             pass
 
         try:
@@ -137,7 +158,15 @@ class SeventeenCYPlusToyotaVehicle(ToyotaVehicle):
                     _LOGGER.debug("Engine status received for VIN %s", self._vin[-4:])
                     self._parse_engine_status(engine_status)
                 else:
-                    _LOGGER.debug("Engine status returned None for VIN %s", self._vin[-4:])
+                    _LOGGER.warning(
+                        "No remote-start status available for VIN ...%s, even though this "
+                        "vehicle has an active remote services subscription. If this persists, "
+                        "check whether this Toyota account is set as the primary remote-services "
+                        "driver for this vehicle -- Toyota returns empty responses to accounts "
+                        "that only have family-shared/guest access, even when the subscription "
+                        "itself is active.",
+                        self._vin[-4:],
+                    )
         except Exception as e:
             _LOGGER.debug("Error fetching engine status: %s", e)
             pass
@@ -162,7 +191,7 @@ class SeventeenCYPlusToyotaVehicle(ToyotaVehicle):
             _LOGGER.debug("GraphQL pre-wake failed: %s", e)
 
         try:
-            await self._client.graphql_confirm_subscription(self._vin)
+            await self._client.graphql_confirm_subscription(self._vin, self.backdoor_type)
         except Exception as e:
             _LOGGER.debug("GraphQL confirm subscription failed: %s", e)
 
@@ -230,17 +259,36 @@ class SeventeenCYPlusToyotaVehicle(ToyotaVehicle):
     # vehicle_health_status
     #
 
-    def _isClosed(self, section) -> bool:
+    # Position words mean the value reports open/closed state; lock words mean it reports
+    # lock state instead. Some generations (e.g. 21MM) report only a single lock-state value
+    # with no position at all, where older generations report position first, then lock state.
+    _POSITION_VALUES = ("closed", "open", "opened")
+    _LOCK_STATE_VALUES = ("locked", "unlocked")
+
+    def _isClosed(self, section) -> Union[bool, None]:
+        """Whether the section reports a closed/open position. Returns None if position
+        isn't reported at all (e.g. a single lock-state-only value)."""
         values = section.get("values", [])
         if not values:
             return False
-        return values[0].get("value", "").lower() == "closed"
+        first_val = values[0].get("value", "").lower()
+        if first_val in self._LOCK_STATE_VALUES:
+            return None
+        return first_val == "closed"
 
-    def _isLocked(self, section) -> bool:
+    def _isLocked(self, section) -> Union[bool, None]:
+        """Whether the section reports lock state, as either the second value entry
+        (older shape) or the only value entry (21MM+ shape). Returns None if lock state
+        isn't reported at all."""
         values = section.get("values", [])
-        if len(values) < 2:
-            return False
-        return values[1].get("value", "").lower() == "locked"
+        if not values:
+            return None
+        first_val = values[0].get("value", "").lower()
+        if len(values) == 1 and first_val in self._LOCK_STATE_VALUES:
+            return first_val == "locked"
+        if len(values) >= 2:
+            return values[1].get("value", "").lower() == "locked"
+        return None
 
     def _parse_vehicle_status(self, vehicle_status: dict) -> None:
         if not vehicle_status:
@@ -273,20 +321,23 @@ class SeventeenCYPlusToyotaVehicle(ToyotaVehicle):
                     if not values:
                         continue
                     first_val = values[0].get("value", "").lower()
-                    if first_val not in ("closed", "open", "opened", "locked", "unlocked"):
+                    if first_val not in self._POSITION_VALUES + self._LOCK_STATE_VALUES:
                         continue
-                    # CLOSED is always the first value entry. So we can use it to determine which subtype to instantiate
-                    if len(values) == 1:
+
+                    closed = self._isClosed(section)
+                    locked = self._isLocked(section)
+
+                    if locked is not None:
+                        # We have lock information -- always represent it as a lockable
+                        # opening even when position isn't reported (closed will be None
+                        # in that case), so lock-state entities stay correct regardless.
                         self._features[
                             self._vehicle_status_category_map[key]
-                        ] = ToyotaOpening(self._isClosed(section))
-                    elif len(values) >= 2:
+                        ] = ToyotaLockableOpening(closed=closed, locked=locked)
+                    elif closed is not None:
                         self._features[
                             self._vehicle_status_category_map[key]
-                        ] = ToyotaLockableOpening(
-                            closed=self._isClosed(section),
-                            locked=self._isLocked(section),
-                        )
+                        ] = ToyotaOpening(closed=closed)
 
     #
     # GraphQL vehicle status parser
@@ -433,11 +484,14 @@ class SeventeenCYPlusToyotaVehicle(ToyotaVehicle):
                 self._features[VehicleFeatures.FuelLevel] = ToyotaNumeric(value, "%")
                 continue
 
-            # vehicle_location has a different shape and different target entity class
+            # vehicle_location has a different shape and different target entity class.
+            # Toyota's own API labels this field "Last Parked", and it's the only location
+            # telemetry provides, so it backs both RealTimeLocation and ParkingLocation
+            # (the latter is otherwise only available via REST/WS, which aren't always reachable).
             if key == "vehicleLocation":
-                self._features[VehicleFeatures.RealTimeLocation] = ToyotaLocation(
-                    value.get("latitude"), value.get("longitude")
-                )
+                location = ToyotaLocation(value.get("latitude"), value.get("longitude"))
+                self._features[VehicleFeatures.RealTimeLocation] = location
+                self._features[VehicleFeatures.ParkingLocation] = location
                 continue
 
             if "Window" in key or "Roof" in key:

--- a/custom_components/toyota_na/patch_seventeen_cy_plus.py
+++ b/custom_components/toyota_na/patch_seventeen_cy_plus.py
@@ -49,6 +49,9 @@ class SeventeenCYPlusToyotaVehicle(ToyotaVehicle):
         "Other Hood": VehicleFeatures.Hood,
     }
 
+    # "vehicleLocation" is deliberately not mapped here -- it needs a different target entity
+    # class (ToyotaLocation, not ToyotaNumeric) and backs two features at once, so it's handled
+    # as a special case in _parse_telemetry() below instead of through this table.
     _vehicle_telemetry_map = {
         "distanceToEmpty": VehicleFeatures.DistanceToEmpty,
         "flTirePressure": VehicleFeatures.FrontDriverTire,
@@ -112,6 +115,9 @@ class SeventeenCYPlusToyotaVehicle(ToyotaVehicle):
         # closed by telemetry for the same poll). vehicle_status running second means it
         # overwrites telemetry's value when it has one, and simply leaves telemetry's value in
         # place on the (common) polls where vehicle_status doesn't report window state at all.
+        # If NEITHER source reports a given feature on a given poll, its entry in self._features
+        # simply isn't touched -- the entity keeps showing whatever it last had, indefinitely,
+        # with no staleness indicator. Known limitation, not specific to this reordering.
         try:
             # telemetry
             telemetry = await self._client.get_telemetry(self._vin, self._region)
@@ -129,6 +135,12 @@ class SeventeenCYPlusToyotaVehicle(ToyotaVehicle):
                     self._last_vehicle_status = vehicle_status
                     self._parse_vehicle_status(vehicle_status)
                 elif self._last_vehicle_status:
+                    # _last_vehicle_status has no TTL/expiry -- if this account permanently loses
+                    # access (see the warning below), every future poll re-parses this same
+                    # snapshot indefinitely, so door/window/lock entities keep showing that last-
+                    # known state forever rather than going unknown. Predates this warning
+                    # message; noted here since the warning could otherwise read as the whole
+                    # story.
                     self._parse_vehicle_status(self._last_vehicle_status)
 
                 # WebSocket cached data (if available) provides additional detail
@@ -264,6 +276,10 @@ class SeventeenCYPlusToyotaVehicle(ToyotaVehicle):
     # Position words mean the value reports open/closed state; lock words mean it reports
     # lock state instead. Some generations (e.g. 21MM) report only a single lock-state value
     # with no position at all, where older generations report position first, then lock state.
+    # This is reverse-engineered from live payloads (diffing a working vs. a family-shared/
+    # degraded account's response for the same vehicle, plus multiple generations' raw API
+    # captures), not from any Toyota documentation -- there's no guarantee a future generation
+    # or API change won't report a third shape these values don't cover.
     _POSITION_VALUES = ("closed", "open", "opened")
     _LOCK_STATE_VALUES = ("locked", "unlocked")
 
@@ -323,6 +339,10 @@ class SeventeenCYPlusToyotaVehicle(ToyotaVehicle):
                     if not values:
                         continue
                     first_val = values[0].get("value", "").lower()
+                    # Deliberate: an unrecognized first value (e.g. a future third status word
+                    # Toyota starts sending) means we just skip this section for this poll,
+                    # leaving whatever feature value already exists from a prior poll in place,
+                    # rather than guessing at its meaning or clearing the feature to unknown.
                     if first_val not in self._POSITION_VALUES + self._LOCK_STATE_VALUES:
                         continue
 
@@ -397,7 +417,12 @@ class SeventeenCYPlusToyotaVehicle(ToyotaVehicle):
                     pos_status = ((window.get("position") or {}).get("status", "")).lower()
                     self._features[feature] = ToyotaOpening(closed=(pos_status == "closed"))
 
-        # Hatch / Trunk / Tailgate -> mapped to VehicleFeatures.Trunk
+        # Hatch / Trunk / Tailgate -> mapped to VehicleFeatures.Trunk. Assumption (not
+        # confirmed against a payload where more than one key was present): a vehicle's rear
+        # cargo access is exactly one body style, so in practice only one of these three keys
+        # should ever actually be present. If that assumption is wrong for some vehicle, this
+        # order (hatch, then trunk, then tailgate) silently decides which one wins -- not a
+        # deliberate priority choice, just iteration order.
         for opening_key in ("hatch", "trunk", "tailgate"):
             opening = vehicle_state.get(opening_key)
             if opening:

--- a/custom_components/toyota_na/patch_seventeen_cy_plus.py
+++ b/custom_components/toyota_na/patch_seventeen_cy_plus.py
@@ -81,6 +81,7 @@ class SeventeenCYPlusToyotaVehicle(ToyotaVehicle):
         region: str,
         backdoor_type: str = None,
         capabilities: dict = None,
+        api_generation: str = None,
     ):
         self._has_remote_subscription = has_remote_subscription
         self._has_electric = has_electric
@@ -97,6 +98,7 @@ class SeventeenCYPlusToyotaVehicle(ToyotaVehicle):
             ApiVehicleGeneration.CY17PLUS,
             backdoor_type,
             capabilities,
+            api_generation,
         )
 
     _last_graphql_status = None  # persist last successful GraphQL status

--- a/custom_components/toyota_na/patch_vehicle.py
+++ b/custom_components/toyota_na/patch_vehicle.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 from toyota_na.client import ToyotaOneClient
 from toyota_na.vehicle.base_vehicle import (
     ApiVehicleGeneration,
@@ -6,13 +8,20 @@ from toyota_na.vehicle.base_vehicle import (
 from toyota_na.vehicle.vehicle_generations.seventeen_cy import SeventeenCYToyotaVehicle
 from toyota_na.vehicle.vehicle_generations.seventeen_cy_plus import SeventeenCYPlusToyotaVehicle
 
-async def get_vehicles(client: ToyotaOneClient) -> list[ToyotaVehicle]:
+async def get_vehicles(
+    client: ToyotaOneClient, exclude_vins: Union[set, None] = None
+) -> list[ToyotaVehicle]:
+    """:param exclude_vins: VINs to skip entirely (no vehicle object constructed, no API calls
+    made for them) -- vehicles a user has explicitly excluded via the Configure option."""
+    exclude_vins = exclude_vins or set()
     api_vehicles = await client.get_user_vehicle_list()
     supportedGenerations = dict((item.value, item) for item in ApiVehicleGeneration)
     vehicles = []
 
     for (i, vehicle) in enumerate(api_vehicles):
         if vehicle["generation"] not in supportedGenerations:
+            continue
+        if vehicle["vin"] in exclude_vins:
             continue
         api_generation = vehicle["generation"]
         if (

--- a/custom_components/toyota_na/patch_vehicle.py
+++ b/custom_components/toyota_na/patch_vehicle.py
@@ -27,6 +27,8 @@ async def get_vehicles(client: ToyotaOneClient) -> list[ToyotaVehicle]:
                 model_year=vehicle["modelYear"],
                 vin=vehicle["vin"],
                 region=vehicle["region"],
+                backdoor_type=vehicle.get("backdoorType"),
+                capabilities=vehicle.get("remoteServiceCapabilities"),
             )
 
         elif ApiVehicleGeneration(vehicle["generation"]) == ApiVehicleGeneration.CY17:

--- a/custom_components/toyota_na/patch_vehicle.py
+++ b/custom_components/toyota_na/patch_vehicle.py
@@ -14,10 +14,11 @@ async def get_vehicles(client: ToyotaOneClient) -> list[ToyotaVehicle]:
     for (i, vehicle) in enumerate(api_vehicles):
         if vehicle["generation"] not in supportedGenerations:
             continue
+        api_generation = vehicle["generation"]
         if (
-            ApiVehicleGeneration(vehicle["generation"]) == ApiVehicleGeneration.CY17PLUS
-            or ApiVehicleGeneration(vehicle["generation"]) == ApiVehicleGeneration.MM21
-            or ApiVehicleGeneration(vehicle["generation"]) == ApiVehicleGeneration.MM24
+            ApiVehicleGeneration(api_generation) == ApiVehicleGeneration.CY17PLUS
+            or ApiVehicleGeneration(api_generation) == ApiVehicleGeneration.MM21
+            or ApiVehicleGeneration(api_generation) == ApiVehicleGeneration.MM24
         ):
             vehicle = SeventeenCYPlusToyotaVehicle(
                 client=client,
@@ -29,6 +30,7 @@ async def get_vehicles(client: ToyotaOneClient) -> list[ToyotaVehicle]:
                 region=vehicle["region"],
                 backdoor_type=vehicle.get("backdoorType"),
                 capabilities=vehicle.get("remoteServiceCapabilities"),
+                api_generation=api_generation,
             )
 
         elif ApiVehicleGeneration(vehicle["generation"]) == ApiVehicleGeneration.CY17:

--- a/custom_components/toyota_na/services.yaml
+++ b/custom_components/toyota_na/services.yaml
@@ -28,6 +28,12 @@ hazards_on:
       selector:
         device:
           integration: toyota_na
+# The dashboard "Hazards Off" button was removed (see COMMAND_BUTTONS in const.py) because it
+# didn't appear to do anything on a real vehicle -- Toyota's own app shows the same behavior
+# (hazards turn on, then auto-off after ~60s, with no manual "off"), suggesting this may not be
+# a real remote capability rather than a bug in this integration specifically. This service is
+# kept for automations since Toyota's API does accept a distinct "off" command and this hasn't
+# been proven broken for every vehicle/account, but don't rely on it doing anything observable.
 hazards_off:
   description: Hazards off your Toyota vehicle.
   fields:

--- a/custom_components/toyota_na/translations/en.json
+++ b/custom_components/toyota_na/translations/en.json
@@ -22,5 +22,27 @@
         "otp_not_logged_in": "Invalid Verification code",
         "unknown": "Unexpected error."
       }
+    },
+    "options": {
+      "step": {
+        "init": {
+          "title": "Vehicles managed by this account",
+          "description": "Choose which vehicles this Toyota account should manage in Home Assistant. Uncheck a vehicle if it's shared with another Toyota account (Toyota \"family sharing\") that you've set up as its own entry in Home Assistant -- that lets the other account manage it instead.",
+          "data": {
+            "managed_vins": "Vehicles to manage from this account"
+          }
+        }
+      },
+      "abort": {
+        "entry_not_loaded": "This integration entry isn't currently loaded, so its vehicle list can't be fetched. Reload the entry and try again.",
+        "cannot_fetch_vehicles": "Couldn't fetch this account's vehicle list from Toyota. Try again in a moment.",
+        "no_vehicles": "This account has no vehicles to configure."
+      }
+    },
+    "issues": {
+      "shared_vehicle": {
+        "title": "A vehicle is shared with another Toyota account",
+        "description": "{vehicle} is visible to more than one Toyota account connected to Home Assistant. It's currently managed by {managing_account}, not {this_account}. If this is intentional, no action is needed -- this message will go away once the vehicle is no longer visible to both accounts, or once you explicitly assign it to one account using this integration's Configure option (Settings > Devices & Services > Toyota (North America) > Configure)."
+      }
     }
   }

--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,7 @@
 {
   "name": "Toyota (North America)",
   "domains": ["device_tracker", "sensor"],
-  "homeassistant": "2021.12.0",
+  "homeassistant": "2024.11.0",
   "iot_class": ["Cloud Polling"],
   "render_readme": true,
   "zip_release": true,


### PR DESCRIPTION
## Summary

A batch of fixes and one new feature found while running this integration daily against a 2020 Tacoma and a 2023 Highlander (the Highlander is shared with a second Toyota account via Toyota's family sharing). Grouped below by concern, not chronology — happy to split into separate PRs if preferred, this ended up as one because several pieces touch the same functions.

## 1. Mechanical bug fixes

- Entity friendly names showed doubled/reversed (e.g. "2023 Highlander Front Driver Door 2023 Highlander") — was building a device-name prefix manually instead of letting HA handle it.
- `vehicleLocation` telemetry was mapped to a dead dict entry, making "Last Parked Location" unrecoverable on any vehicle whose REST `vehicle_status` doesn't report position.
- GraphQL confirm-subscription hardcoded `backdoorType: "hatch"`, wrong for non-hatch vehicles (e.g. pickup tailgates).
- `diagnostics.py` had an argument-order bug silently sending the vehicle's generation string as the telemetry endpoint's region parameter.
- Remote commands weren't gated on `remoteServiceCapabilities` — the integration would send commands Toyota already reported as unsupported.
- Door/lock parsing assumed a single reported value was always a position string; some responses report lock-state only, silently misparsed as "open" with lock state lost entirely.
- `vehicle_status` and telemetry can disagree on window/moonroof state for the same poll; parsing order changed so the fresher source wins.
- Added cleanup for zombie binary_sensor entities created for features a vehicle structurally can't have (e.g. Trunk on a tailgate body).
- Disabled the AppSync WebSocket for 17CYPLUS vehicles, confirmed to work fully via REST alone — left running for 21MM/24MM as a fallback since those haven't been personally verified.

## 2. New: button platform

Adds real button entities for Remote Start/Stop, Hazards On, and Refresh — these previously only existed as bare services with no entity, so they never appeared as device-card controls. Buttons are gated by `supports_command()` at creation time.

**No button for Hazards Off**, deliberately: live testing showed it has no observable effect on a real vehicle, matching Toyota's own app (hazards there are momentary, auto-off after ~60s, no manual "off" even in Toyota's app). The `hazards_off` service is left alone for automations since it's never been proven broken everywhere — just never proven working.

## 3. Fix: entity collisions when a vehicle is shared across two accounts

The actual bug that started this: a vehicle visible to two Toyota accounts (family sharing), each its own config entry, had no protection against both creating entities for the same VIN. Whichever entry loaded second silently lost every entity to "already exists - ignoring" — e.g. pressing "Hazards Off" looked like it worked but was actually bound to the wrong account's session.

- **VIN claim guard**: the first config entry to see a VIN each refresh manages it; any other entry skips entity creation for it and raises a Repair issue instead of colliding. Unconditional, no config needed — single-account installs are unaffected, and entity `unique_id`/device identity is unchanged.
- **Options flow** (Configure): lets a user explicitly exclude a vehicle from an account so the other account's entry can claim it deliberately, instead of by refresh-order.
- **Device pruning**: excluding a vehicle (or losing a claim conflict) removes that entry's now-unclaimed device — but only for confirmed reasons (explicit exclusion, or a claim genuinely lost that cycle), *never* from a vehicle merely missing from one poll, since a transient API hiccup returning a short vehicle list must never be mistaken for "this vehicle is gone" and delete real entities. (This distinction was added after an internal review caught the first version of this pruning logic doing exactly that.)
- **Manual device removal**: added `async_remove_config_entry_device` for the one case that isn't auto-pruned — a vehicle actually removed from the account (e.g. sold).
- Requires Home Assistant 2024.11+ (bumped in `hacs.json`) since the options flow relies on `OptionsFlow`'s automatic `self.config_entry` rather than a custom `__init__`, which HA deprecated that release.

## Backward compatibility

Single-account installs (the overwhelming majority) see no behavior change from item 3 at all — the claim guard and pruning logic are no-ops unless a VIN is genuinely contested. No entity `unique_id` or device identifier changes anywhere in this PR.

## Testing

- Every parsing fix verified against live API payloads (diffed a working vs. a permission-degraded account's response for the same vehicle).
- Live-tested lock/unlock/engine start/stop/refresh against two real vehicles.
- Live-tested the shared-vehicle fix against two real Toyota accounts sharing one vehicle: confirmed the collision is gone and commands now route to the correct account.
- Claim-guard, pruning, and issue-lifecycle logic covered by standalone state-machine simulations (conflict, steady state, release, re-claim, and the "loser removed without ever claiming" edge case).
- Ran with debug logging on for ~2.5 days of normal daily use on my own instance (deployed via a custom HACS build ahead of this PR, not merged anywhere upstream): 591/592 successful refreshes (the one failure was a transient network error reaching Toyota's own auth server, unrelated to this PR, self-healed on the next retry), zero entity collisions, zero reload storms despite ~590 real token-refresh writes to entry.data (confirming the reload-listener fix holds under real load, not just in a test).

## Things worth knowing as a reviewer

- A Repair issue can go stale until the losing entry's next reload if sharing is revoked mid-session — self-heals on restart, not fixed proactively (deemed not worth the extra complexity).
- A losing entry logs a WARNING every ~10 min until the conflict is resolved — semi-intentional, gives the user a reason to act.
- The options flow does a second Toyota API call on submit (fetches the vehicle list twice across the flow) — minor, not fixed.

*Assisted by Claude Code. The plan and any other details can be shared if anyone would like to review it.*