### PR TITLE
Update API key and app version in headers

### DIFF
--- a/custom_components/toyota_na/patch_client.py
+++ b/custom_components/toyota_na/patch_client.py
@@ -48,12 +48,12 @@ async def get_telemetry(self, vin, region="US", generation="17CYPLUS"):
 async def _auth_headers(self):
     return {
         "AUTHORIZATION": "Bearer " + await self.auth.get_access_token(),
-        "X-API-KEY": self.API_KEY,
+        "X-API-KEY": RESOLVER_API_KEY,
         "X-GUID": await self.auth.get_guid(),
         "X-CHANNEL": "ONEAPP",
         "X-BRAND": "T",
         "x-region": "US",
-        "X-APPVERSION": "3.1.0",
+        "X-APPVERSION": "3.4.0",
         "X-LOCALE": "en-US",
         "User-Agent": USER_AGENT,
         "Accept": "application/json",
@@ -185,7 +185,7 @@ async def graphql_request(self, operation_name, query, variables):
         "x-deviceid": self.auth.get_device_id(),
         "X-APPBRAND": "T",
         "x-channel": "ONEAPP",
-        "X-APPVERSION": "3.1.0",
+        "X-APPVERSION": "3.4.0",
         "X-OSNAME": "Android",
         "X-OSVERSION": "14",
         "X-LOCALE": "en-US",


### PR DESCRIPTION
Fixes #185.

Toyota began rejecting the legacy API key used for REST requests, causing vehicle discovery to fail with `APIGW-403 Unauthorized/Forbidden`.

This change:

Uses the current `RESOLVER_API_KEY` for Toyota REST requests.
Updates the REST and GraphQL `X-APPVERSION` headers to `3.4.0`, matching the current official Toyota Android app.